### PR TITLE
(Hopefully temporary) fix to Win32 unclickable navi

### DIFF
--- a/main.js
+++ b/main.js
@@ -60,7 +60,7 @@ app.on('ready', () =>
     })
   }
   else {
-    win = new BrowserWindow({width: 1100, height: 660, frame:false, backgroundColor: '#000', show:false, resizable:true, autoHideMenuBar: true, icon: __dirname + '/icon.ico'})
+    win = new BrowserWindow({width: 1100, height: 660, frame:process.platform === 'win32', backgroundColor: '#000', show:false, resizable:true, autoHideMenuBar: true, icon: __dirname + '/icon.ico'})
 
     win.loadURL(`file://${__dirname}/sources/index.html`)
 


### PR DESCRIPTION
Hi!

I noticed that the navi headers aren't clickable / hoverable on win32. Turns out that it's probably a bug in Electron (see https://github.com/electron/electron/issues/7696) that somehow messes up the mouse events in a frameless window. So, making Left's window frameless-less.. frameful... display its frame, the mouse events now fire as expected.

Having never touched the insides of an Electron app, I'm not sure if there is something more elegant that can be done inside the Left codebase, but this at least makes the navi functional.