### PR TITLE
horizontal margins change

### DIFF
--- a/sources/links/main.css
+++ b/sources/links/main.css
@@ -1,16 +1,18 @@
 body { background:#f8f8f8; font-family: 'input_mono_medium'; font-size: 12px; overflow-y: hidden}
-body navi { display: block;height: calc(100vh - 120px);width: calc(50vw - 330px);left: 0px;position: absolute;padding: 30px;color: #333; -webkit-user-select: none;-webkit-app-region: drag; overflow-y: hidden; padding-top:90px;}
+body navi { display: block;height: calc(100vh - 120px);width: calc((100vw / 6));left: 0px;position: absolute;padding: 30px;color: #333; -webkit-user-select: none;-webkit-app-region: drag; overflow-y: hidden; padding-top:90px;}
 body navi li { display: block;line-height: 20px;cursor: pointer; position: relative; text-transform: uppercase;}
 body navi li:hover::before { content:">"; position: absolute; left:-15px;}
 body navi li.note { padding-left:7px; color:#999; text-transform: capitalize;}
 body navi li.active::before { content:":"; position: absolute; left:-15px; }
 body navi li span { float:right; }
-body stats { display: block;border-bottom: 0px;color: #999;margin-top: 30px;position: fixed;bottom:10px;left: calc(50vw - 270px);line-height: 40px;width:540px;height:40px;overflow: hidden; padding-left:30px; }
+body stats { display: block;border-bottom: 0px;color: #999;margin-top: 30px;position: fixed;bottom:10px;left: calc(20vw + 60px - 24px);line-height: 40px;width:540px;height:40px;overflow: hidden; padding-left:30px; }
 body stats .right { float:right; }
 body stats b { color:#000; font-family: 'input_mono_regular';}
 body stats i { text-decoration: underline; }
-body textarea { padding: 90px 30px 0px; height: calc(100vh - 60px);display: block;color: black;width: 540px;position: fixed;left: calc(50vw - 270px);line-height: 20px;resize: none; background:transparent; overflow: hidden; max-width:560px; }
+body textarea { padding: 90px 30px 0px; height: calc(100vh - 60px);display: block;color: black;width: 540px;position: fixed;left: calc((100vw / 6) + 60px);line-height: 20px;resize: none; background:transparent; overflow: hidden; max-width:560px; }
 body scrollbar { display: block; background:#ccc; width:1px; height:1px; position:fixed; left:0; bottom:0px; }
 ::selection { background:#ddd; color:#000; opacity:1.0;}
 
 body.mobile navi { display:none; }
+body.mobile textarea { left: calc(50vw - 270px) }
+body.mobile stats { left: calc(50vw - 270px) }

--- a/sources/scripts/events.js
+++ b/sources/scripts/events.js
@@ -137,7 +137,7 @@ document.addEventListener('wheel', function(e)
 
 window.addEventListener('resize', function(e)
 {
-  if(window.innerWidth < 900){
+  if(window.innerWidth < 720){
     document.body.className = "mobile";
   }
   else{


### PR DESCRIPTION
this allows smaller screen sizes to display the navigation tab, by cutting out the whitespace to the right of the text field before it switches to mobile mode. (from 900px min to 720px)

Mobile mode itself is kept the same, though.

