### PR TITLE
navi update delay bugfix

### DIFF
--- a/sources/scripts/events.js
+++ b/sources/scripts/events.js
@@ -90,7 +90,12 @@ document.onkeydown = function key_down(e)
   if(e.key == " " || e.key == "Enter"){
     left.selection.index = 0;
   }
-
+  
+  if(e.key.substring(0,5) == "Arrow"){
+    setTimeout(() => left.refresh(), 0) //force the refresh event to happen after the selection updates
+    return;
+  }
+  
   left.refresh();
 };
 


### PR DESCRIPTION
when moving the cursor with the arrow keys, the navigation would always be one update behind the cursor, causing things like this: 
![screenshot_2](https://user-images.githubusercontent.com/32149949/31108682-9c60fbc6-a7af-11e7-9eb4-f4913d713c22.png)

this was caused by left.active_line_id being based on the cursor's selection, something that updated after the onkeydown event (but only with the arrow keys, seemingly)

this change makes the refresh event happen after that update