### PR TITLE
marker syntax parse update

### DIFF
--- a/sources/index.html
+++ b/sources/index.html
@@ -14,9 +14,12 @@
     <script src="scripts/dict.js"></script>
     <script src="scripts/operator.js"></script>
     <script src="scripts/left.js"></script>
+    <script src="scripts/options.js"></script>
   </head>
   <body>
     <script>
+      
+      const {webFrame} = require('electron')
 
       const {dialog,app} = require('electron').remote;
       const fs = require('fs');

--- a/sources/scripts/events.js
+++ b/sources/scripts/events.js
@@ -96,6 +96,14 @@ document.onkeydown = function key_down(e)
     return;
   }
   
+  if(e.key == "+" && (e.ctrlKey || e.metaKey)) {
+    e.preventDefault();
+    left.options.set_zoom(left.options.zoom+0.1)
+  }
+  else if(e.key == "-" && (e.ctrlKey || e.metaKey)) {
+    e.preventDefault();
+    left.options.set_zoom(left.options.zoom-0.1)
+  }
   left.refresh();
 };
 

--- a/sources/scripts/left.js
+++ b/sources/scripts/left.js
@@ -5,6 +5,7 @@ function Left()
   this.operator = new Operator();
   this.navi = new Navi();
   this.source = new Source();
+  this.options = new Options();
 
   this.textarea_el    = document.createElement('textarea');
   this.stats_el       = document.createElement('stats');
@@ -62,6 +63,7 @@ function Left()
     left.suggestion = (next_char == "" || next_char == " " || next_char == "\n") ? left.dictionary.find_suggestion(left.selection.word) : null;
 
     this.navi.update();
+    this.options.update();
     this.update_stats();
   }
 
@@ -166,6 +168,47 @@ function Left()
   {
     var suggestion = left.suggestion;
     this.inject(suggestion.substr(left.selection.word.length,suggestion.length));
+  }
+
+  this.replace_line = function(id,new_text)
+  {
+    let lineArr = this.textarea_el.value.split("\n",parseInt(id)+1)
+    let arrJoin = lineArr.join("\n")
+
+    let from = arrJoin.length-lineArr[id].length;
+    let to = arrJoin.length;
+    
+    //splicing the string
+    let new_text_value = this.textarea_el.value.slice(0,from) + new_text + this.textarea_el.value.slice(to)
+
+    // the cursor automatically moves to the changed position, so we have to set it back
+    let cursor_start = this.textarea_el.selectionStart;
+    let cursor_end = this.textarea_el.selectionEnd;
+    let old_length = this.textarea_el.value.length
+    //setting text area
+    this.textarea_el.value = new_text_value
+    //adjusting the cursor position for the change in length
+    let length_dif = this.textarea_el.value.length - old_length
+    if(cursor_start>to) {
+    cursor_start += length_dif
+    cursor_end += length_dif
+    }
+    //setting the cursor position
+    if(this.textarea_el.setSelectionRange){
+    this.textarea_el.setSelectionRange(cursor_start,cursor_end);
+    }
+    else if(this.textarea_el.createTextRange){
+      var range = this.textarea_el.createTextRange();
+      range.collapse(true);
+      range.moveEnd('character',cursor_end);
+      range.moveStart('character',cursor_start);
+      range.select();
+    }
+    //setting the scroll position
+    var perc = (left.textarea_el.selectionEnd/parseFloat(left.chars_count));
+    var offset = 60;
+    this.textarea_el.scrollTop = (this.textarea_el.scrollHeight * perc) - offset;
+    //this function turned out a lot longer than I was expecting. Ah well :/
   }
 
   this.go_to_line = function(id)

--- a/sources/scripts/navi.js
+++ b/sources/scripts/navi.js
@@ -37,14 +37,15 @@ function Navi()
 
     for(var line_id in lines){
       var line = lines[line_id];
-      if(line.substr(0,2) == "# "){
-        var text = line.replace("@ ","").replace("# ","");
-        this.markers.push({text:text,line:line_id,type:"header"});
-      }
-      else if(line.substr(0,3) == "## "){
-        var text = line.replace("@ ","").replace("## ","");
+      if(line.substr(0,2).replace(/@/g,"#") == "##"){
+        var text = line.replace(/ +/,"").substring(2);
         this.markers.push({text:text,line:line_id,type:"note"});
       }
+      else if(line.substr(0,1).replace(/@/g,"#") == "#"){
+        var text = line.replace(/ +/,"").substring(1);
+        this.markers.push({text:text,line:line_id,type:"header"});
+      }
+      
     }
     // End
   }

--- a/sources/scripts/options.js
+++ b/sources/scripts/options.js
@@ -1,0 +1,49 @@
+function Options() {
+  this.zoom = 1
+  this.update = function () {
+    var text = left.textarea_el.value;
+    var lines = text.split("\n");
+
+    left.lines_count = lines.length;
+
+    for (var line_id in lines) {
+      var line = lines[line_id].toLowerCase()
+      this.check_string(line, /~ *(?:left)?.?zoom *=? */, "number", (res) => {
+        this.zoom = res
+        webFrame.setZoomFactor(res)
+      })
+    }
+  }
+
+  this.check_string = function (text, regex, type, cb) {
+    if ( regex.test(text)) {
+      this.check_json_type(text.replace(regex, ""), type, cb)
+    }
+  }
+
+  this.check_json_type = function (text, type, cb) {
+    try {
+      let res = JSON.parse(text)
+      if (typeof res == type) {
+        cb(res)
+      }
+    } catch (error) { }
+  }
+  this.set_zoom = function(new_zoom) {
+    if(new_zoom<0.1) new_zoom = 0.1
+    new_zoom = Math.round(new_zoom*10)/10
+    this.zoom = new_zoom
+    webFrame.setZoomFactor(new_zoom)
+    var text = left.textarea_el.value;
+    var lines = text.split("\n");
+    for (var line_id in lines) {
+      var line = lines[line_id].toLowerCase()
+      this.check_string(line, /~ *(?:left)?.?zoom *=? */, "number", (res) => {
+        let c_line = line.replace(/~ *(?:left)?.?zoom *=? */, "")
+        line_dif = line.length-c_line.length
+
+          left.replace_line(line_id,line.substring(0,line_dif)+new_zoom)
+      })
+    }
+  }
+}


### PR DESCRIPTION
this allows users to use more varied syntax to create markers, hopefully making the interface more intuitive.

This consists of two changes:

1. allow users to use no (or any amount of) spaces between the pound sign(s) and the marker name
2. allow the use of at signs instead of pound signs. (there was a partially completed implementation of this in the code, I assumed this was a feature you wanted. Feel free to remove it if I was wrong)