### PR TITLE
navi bugfixes

### DIFF
--- a/sources/links/main.css
+++ b/sources/links/main.css
@@ -2,7 +2,7 @@ body { background:#f8f8f8; font-family: 'input_mono_medium'; font-size: 12px; ov
 body navi { display: block;height: calc(100vh - 120px);width: calc((100vw / 6));left: 0px;position: absolute;padding: 30px;color: #333; -webkit-user-select: none;-webkit-app-region: drag; overflow-y: hidden; padding-top:90px;}
 body navi li { display: block;line-height: 20px;cursor: pointer; position: relative; text-transform: uppercase; -webkit-app-region: no-drag;}
 body navi li:hover::before { content:">"; position: absolute; left:-15px;}
-body navi li.note { padding-left:7px; color:#999; text-transform: capitalize;}
+body navi li.note { padding-left:7px; color:#999; text-transform: lowercase;}
 body navi li.active::before { content:":"; position: absolute; left:-15px; }
 body navi li span { float:right; }
 body stats { display: block;border-bottom: 0px;color: #999;margin-top: 30px;position: fixed;bottom:10px;left: calc(20vw + 60px - 24px);line-height: 40px;width:540px;height:40px;overflow: hidden; padding-left:30px; }

--- a/sources/links/main.css
+++ b/sources/links/main.css
@@ -1,6 +1,6 @@
 body { background:#f8f8f8; font-family: 'input_mono_medium'; font-size: 12px; overflow-y: hidden}
 body navi { display: block;height: calc(100vh - 120px);width: calc((100vw / 6));left: 0px;position: absolute;padding: 30px;color: #333; -webkit-user-select: none;-webkit-app-region: drag; overflow-y: hidden; padding-top:90px;}
-body navi li { display: block;line-height: 20px;cursor: pointer; position: relative; text-transform: uppercase;}
+body navi li { display: block;line-height: 20px;cursor: pointer; position: relative; text-transform: uppercase; -webkit-app-region: no-drag;}
 body navi li:hover::before { content:">"; position: absolute; left:-15px;}
 body navi li.note { padding-left:7px; color:#999; text-transform: capitalize;}
 body navi li.active::before { content:":"; position: absolute; left:-15px; }
@@ -11,6 +11,7 @@ body stats b { color:#000; font-family: 'input_mono_regular';}
 body stats i { text-decoration: underline; }
 body textarea { padding: 90px 30px 0px; height: calc(100vh - 60px);display: block;color: black;width: 540px;position: fixed;left: calc((100vw / 6) + 60px);line-height: 20px;resize: none; background:transparent; overflow: hidden; max-width:560px; }
 body scrollbar { display: block; background:#ccc; width:1px; height:1px; position:fixed; left:0; bottom:0px; }
+div {width: 480px;line-height: 20px;font-family: 'input_mono_medium'; font-size: 12px;white-space: pre-wrap; word-wrap:break-word}
 ::selection { background:#ddd; color:#000; opacity:1.0;}
 
 body.mobile navi { display:none; }

--- a/sources/scripts/left.js
+++ b/sources/scripts/left.js
@@ -62,8 +62,8 @@ function Left()
 
     left.suggestion = (next_char == "" || next_char == " " || next_char == "\n") ? left.dictionary.find_suggestion(left.selection.word) : null;
 
-    this.navi.update();
     this.options.update();
+    this.navi.update();
     this.update_stats();
   }
 

--- a/sources/scripts/left.js
+++ b/sources/scripts/left.js
@@ -185,6 +185,7 @@ function Left()
     let cursor_start = this.textarea_el.selectionStart;
     let cursor_end = this.textarea_el.selectionEnd;
     let old_length = this.textarea_el.value.length
+    let old_scroll = this.textarea_el.scrollTop
     //setting text area
     this.textarea_el.value = new_text_value
     //adjusting the cursor position for the change in length
@@ -205,9 +206,7 @@ function Left()
       range.select();
     }
     //setting the scroll position
-    var perc = (left.textarea_el.selectionEnd/parseFloat(left.chars_count));
-    var offset = 60;
-    this.textarea_el.scrollTop = (this.textarea_el.scrollHeight * perc) - offset;
+    this.textarea_el.scrollTop = old_scroll
     //this function turned out a lot longer than I was expecting. Ah well :/
   }
 
@@ -231,7 +230,7 @@ function Left()
   }
   
   this.go_to_fromTo = function(from,to) {
-    if(this.textarea_el.setSelectionRange){
+     if(this.textarea_el.setSelectionRange){
       this.textarea_el.setSelectionRange(from,to);
      }
      else if(this.textarea_el.createTextRange){
@@ -242,11 +241,16 @@ function Left()
        range.select();
      }
      this.textarea_el.focus();
- 
-     var perc = (left.textarea_el.selectionEnd/parseFloat(left.chars_count));
-     var offset = 60;
-     this.textarea_el.scrollTop = (this.textarea_el.scrollHeight * perc) - offset;
+     this.scroll_to(from,to)
      return from == -1 ? null : from;
+  }
+  this.scroll_to = function(from,to) { //creates a temp div which 
+    let text_val = this.textarea_el.value
+    var div = document.createElement("div");
+    div.innerHTML=text_val.slice(0,from); 
+    document.body.appendChild(div);
+    this.textarea_el.scrollTop = div.offsetHeight - 60
+    div.remove()
   }
 
   this.go_to_word = function(word,from = 0, tries = 0, starting_with = false, ending_with = false)

--- a/sources/scripts/navi.js
+++ b/sources/scripts/navi.js
@@ -11,12 +11,17 @@ function Navi()
     this.el.innerHTML = "";
     var active_line_id = left.active_line_id();
     var i = 0;
+    var marker_num = left.options.marker_num
     for(marker_id in this.markers){
       var marker = this.markers[marker_id];
       var next_marker = this.markers[i+1];
       var el = document.createElement('li');
       el.destination = marker.line;
-      el.innerHTML = marker.text;
+      if(marker_num) {
+        el.innerHTML = marker.text+"<span>"+marker.line+"</span>";
+      } else {
+        el.innerHTML = marker.text;
+      }
       el.className = active_line_id >= marker.line && (!(next_marker) || active_line_id < next_marker.line) ? marker.type+" active" : marker.type;
       el.className += marker.type == "header" ? " fh" : " fm";
       el.onmouseup = function on_mouseup(e){ left.go_to_line(e.target.destination); }
@@ -39,6 +44,7 @@ function Navi()
       var line = lines[line_id];
       if(line.substr(0,2).replace(/@/g,"#") == "##"){
         var text = line.replace(/ +/,"").substring(2);
+        text = text.replace(/#+/,(match) => {console.log(match);return new Array(match.length+1).join("\u200b ")})
         this.markers.push({text:text,line:line_id,type:"note"});
       }
       else if(line.substr(0,1).replace(/@/g,"#") == "#"){

--- a/sources/scripts/navi.js
+++ b/sources/scripts/navi.js
@@ -44,7 +44,7 @@ function Navi()
       var line = lines[line_id];
       if(line.substr(0,2).replace(/@/g,"#") == "##"){
         var text = line.replace(/ +/,"").substring(2);
-        text = text.replace(/#+/,(match) => {console.log(match);return new Array(match.length+1).join("\u200b ")})
+        text = text.replace(/[@#]+/,(match) => {console.log(match);return new Array(match.length+1).join("\u200b ")})
         this.markers.push({text:text,line:line_id,type:"note"});
       }
       else if(line.substr(0,1).replace(/@/g,"#") == "#"){

--- a/sources/scripts/options.js
+++ b/sources/scripts/options.js
@@ -1,5 +1,6 @@
 function Options() {
   this.zoom = 1
+  this.marker_num = false
   this.update = function () {
     var text = left.textarea_el.value;
     var lines = text.split("\n");
@@ -11,6 +12,9 @@ function Options() {
       this.check_string(line, /~ *(?:left)?.?zoom *=? */, "number", (res) => {
         this.zoom = res
         webFrame.setZoomFactor(res)
+      })
+      this.check_string(line, /~ *(?:left)?.?(?:marker|navi)[._ ]?num? *=? */, "boolean", (res) => {
+        this.marker_num = res
       })
     }
   }


### PR DESCRIPTION
changes:
1. added css tag to allow mouse over and click events in the list elements when the navi element is being used for dragging. On windows the list elements were broken when the frame was removed without this.
2. fixed the 'scroll to' code in the `go_to_fromto `and `replace_line `functions.

This was initially intended to just be the first change, but I noticed the second when I was about to commit, thinking it would be a small change. It took 6 hours. I pray I didn't miss a bug.