### PR TITLE
expanded options and actions

### DIFF
--- a/sources/links/main.css
+++ b/sources/links/main.css
@@ -16,4 +16,4 @@ div {width: 480px;line-height: 20px;font-family: 'input_mono_medium'; font-size:
 
 body.mobile navi { display:none; }
 body.mobile textarea { left: calc(50vw - 270px) }
-body.mobile stats { left: calc(50vw - 270px) }
+body.mobile stats { left: calc(50vw - 270px); -webkit-app-region: drag; }

--- a/sources/scripts/dict.js
+++ b/sources/scripts/dict.js
@@ -30,7 +30,7 @@ function Dict()
 
   this.find_suggestion = function(to_word)
   {
-    if(!this.is_suggestions_enabled){ return null; }
+    if(!left.options.suggestions){ return null; }
 
     to_word = to_word.toLowerCase();
 
@@ -56,7 +56,7 @@ function Dict()
   this.find_synonym = function(to_word)
   {
     to_word = to_word.toLowerCase();
-    if(!this.is_synonyms_enabled && this.synonyms){ return null; }
+    if(!left.options.synonyms && this.synonyms){ return null; }
 
     if(this.synonyms[to_word]){ return squash(this.synonyms[to_word]); }
 

--- a/sources/scripts/left.js
+++ b/sources/scripts/left.js
@@ -138,7 +138,7 @@ function Left()
     var l = this.active_word_location();
     var w = left.textarea_el.value.substr(l.from,l.to-l.from);
 
-    // Preserve capitali.ation
+    // Preserve capitalization
     if(w.substr(0,1) == w.substr(0,1).toUpperCase()){
       word = word.substr(0,1).toUpperCase()+word.substr(1,word.length);
     }

--- a/sources/scripts/navi.js
+++ b/sources/scripts/navi.js
@@ -49,7 +49,7 @@ function Navi()
       var line = lines[line_id];
       if(line.substr(0,2).replace(/@/g,"#") == "##"){
         var text = line.replace(/ +/,"").substring(2);
-        text = text.replace(/[@#]+/,(match) => {console.log(match);return new Array(match.length+1).join("\u200b ")})
+        text = text.replace(/[@#]+/,(match) => {return new Array(match.length+1).join("\u200b ")})
         this.markers.push({text:text,line:line_id,type:"note"});
       }
       else if(line.substr(0,1).replace(/@/g,"#") == "#"){
@@ -90,19 +90,12 @@ function Navi()
   {
     var active_line_id = left.active_line_id();
 
-    var i = 0;
     for(marker_id in this.markers){
-      var next_marker = this.markers[i+1];
-
-      if(this.markers[i-1] && next_marker && next_marker.line > active_line_id){
-        left.go_to_line(this.markers[i-1].line);
+      var marker = this.markers[this.markers.length-(parseInt(marker_id)+1)];
+      if(marker.line < active_line_id){
+        left.go_to_line(marker.line);
         break;
       }
-      else if(!next_marker){
-        left.go_to_line(this.markers[i-1].line);
-        break;
-      }
-      i += 1;
     }
   }
 }

--- a/sources/scripts/options.js
+++ b/sources/scripts/options.js
@@ -2,39 +2,32 @@ function Options()
 {
   this.zoom = 1
   this.marker_num = false
-<<<<<<< HEAD
   this.suggestions = true
   this.synonyms = true
-  this.update = function () {
-=======
-
-  this.update = function()
+  this.update = function () 
   {
->>>>>>> 837553ddcf7a625ca25ddc64b2e74520941a8173
     var text = left.textarea_el.value;
     var lines = text.split("\n");
 
     left.lines_count = lines.length;
-    if(left.last_char.length == 1) {
-      for (var line_id in lines) {
-        var line = lines[line_id].toLowerCase()
-        this.check_string(line, /~ *(?:left)?.?zoom *=?[ \(]*([^ \(\)]*)[ \)]*/, "number", (res) => {
-          this.zoom = res
-          if(webFrame){webFrame.setZoomFactor(res) }
-        })
-        this.check_string(line, /~ *(?:left)?.?(?:marker|navi)[._ ]?num? *=?[ \(]*([^ \(\)]*)[ \)]*/, "boolean", (res) => {
-          this.marker_num = res
-        })
-        this.check_string(line, /~ *(?:left)?.?theme *=?[ \(]*([^ \(\)]*)[ \)]*/, "string", (res) => {
-          left.theme.load(res)
-        })
-        this.check_string(line, /~ *(?:left)?.?suggestions? *=?[ \(]*([^ \(\)]*)[ \)]*/, "boolean", (res) => {
-          this.suggestions=res
-        })
-        this.check_string(line, /~ *(?:left)?.?synonyms? *=?[ \(]*([^ \(\)]*)[ \)]*/, "boolean", (res) => {
-          this.synonyms=res
-        })
-      }
+    for (var line_id in lines) {
+      var line = lines[line_id]
+      this.check_string(line, /~ *(?:left)?.?zoom *=?[ \(]*([^ \(\)]*)[ \)]*/i, "number", (res) => {
+        this.zoom = res
+        if(webFrame){webFrame.setZoomFactor(res) }
+      })
+      this.check_string(line, /~ *(?:left)?.?(?:marker|navi)[._ ]?nums? *=?[ \(]*([^ \(\)]*)[ \)]*/i, "boolean", (res) => {
+        this.marker_num = res
+      })
+      this.check_string(line, /~ *(?:left)?.?theme *=?[ \(]*([^ \(\)]*)[ \)]*/i, "string", (res) => {
+        left.theme.load(res)
+      })
+      this.check_string(line, /~ *(?:left)?.?suggestions? *=?[ \(]*([^ \(\)]*)[ \)]*/i, "boolean", (res) => {
+        this.suggestions=res
+      })
+      this.check_string(line, /~ *(?:left)?.?synonyms? *=?[ \(]*([^ \(\)]*)[ \)]*/i, "boolean", (res) => {
+        this.synonyms=res
+      })
     }
   }
 
@@ -48,14 +41,24 @@ function Options()
 
   this.check_json_type = function (text, type, cb)
   {
-    if(is_json(text)) {
-      let res = JSON.parse(text)
+    text = text.replace(/ *$/,"")
+    if(is_json(text.toLowerCase())) {
+      let res = JSON.parse(text.toLowerCase())
       if (typeof res == type) {
         cb(res)
       }
     } else {
-      if(type == "string") {
-        cb(text.replace(/ *$/,""))
+      switch(type) {
+        case "string":
+          cb(text)
+          break;
+        case "boolean":
+          if(text == "yes") {
+            cb(true)
+          } else if(text == "no") {
+            cb(false)
+          }
+          break;
       }
     }
   }
@@ -84,16 +87,15 @@ function Options()
     var found = false
     var text = left.textarea_el.value;
     var lines = text.split("\n");
-    var line = lines[left.active_line_id()].toLowerCase()
-    this.check_string(line, /> *=? *(?:go[ _]?to) *=?[ \(]*([^ \(\)]*)[ \)]*/, "number", (res) => {
+    var line = lines[left.active_line_id()]
+    this.check_string(line, /> *=? *(?:go[ _]?to) *=?[ \(]*([^ \(\)]*)[ \)]*/i, "number", (res) => {
       found = true
       let actLine = left.active_line_id()
       left.go_to_line(res)
       left.replace_line(actLine,"",true)
     })
-    this.check_string(line, /> *=? *replace *=?[ \(]*([^ \(\)]*)[ \)]*/, "string", (res) => {
+    this.check_string(line, /> *=? *replace *=?[ \(]*([^ \(\)]*)[ \)]*/i, "string", (res) => {
       let actLine = left.active_line_id()
-      console.log("match")
       found = true
       let res_array = res.split(/,/)
       res_array = res_array.map((a) => a.replace(/^ +/,"").replace(/ +$/,""))
@@ -110,7 +112,7 @@ function Options()
           text_before_length_dif = 0; //the diffrence in length between the text before the cursor
       try {
         let replace_num = text_val.join("").match(regex).length
-        replace_string = "" + replace_num-1 + " occurrence" + (replace_num>1 ? "s" : "") + " replaced"
+        replace_string = "" + replace_num + " occurrence" + (replace_num==1 ? "" : "s") + " replaced"
         text_before_length_dif = text_val[0].replace(regex,res_array[1]).length-text_val[0].length
       } catch (error) {
         replace_string = "no occurrences found"

--- a/sources/scripts/options.js
+++ b/sources/scripts/options.js
@@ -97,6 +97,8 @@ function Options()
     this.check_string(line, /> *=? *replace *=?[ \(]*([^ \(\)]*)[ \)]*/i, "string", (res) => {
       let actLine = left.active_line_id()
       found = true
+      //// declarations
+      
       let res_array = res.split(/,/)
       res_array = res_array.map((a) => a.replace(/^ +/,"").replace(/ +$/,""))
       let regex = new RegExp(res_array[0], "g")
@@ -109,15 +111,25 @@ function Options()
       text_val = [text_val.slice(0,from),text_val.slice(to)]
 
       let replace_string,
-          text_before_length_dif = 0; //the diffrence in length between the text before the cursor
-      try {
-        let replace_num = text_val.join("").match(regex).length
-        replace_string = "" + replace_num + " occurrence" + (replace_num==1 ? "" : "s") + " replaced"
-        text_before_length_dif = text_val[0].replace(regex,res_array[1]).length-text_val[0].length
-      } catch (error) {
-        replace_string = "no occurrences found"
+      text_before_length_dif = 0; //the diffrence in length between the text before the cursor
+
+      //// computation
+
+      if(res_array.length == 2) { // there are two arguments
+        try {
+          let replace_num = text_val.join("").match(regex).length
+          replace_string = "" + replace_num + " occurrence" + (replace_num==1 ? "" : "s") + " replaced"
+          text_before_length_dif = text_val[0].replace(regex,res_array[1]).length-text_val[0].length
+        } catch (error) {
+          replace_string = "no occurrences found"
+        }
+      } else { // there is not two arguments
+        replace_string = "replace action requires two comma separated arguments"
       }
-      left.textarea_el.value = left.textarea_el.value.replace(regex,res_array[1])
+
+      //// execution
+
+      if(res_array.length == 2) left.textarea_el.value = left.textarea_el.value.replace(regex,res_array[1])
       let cursor_return_index = from+text_before_length_dif+replace_string.length // the place to set the cursor to
       left.go_to_fromTo(cursor_return_index,cursor_return_index)
       left.replace_line(actLine,replace_string,false)


### PR DESCRIPTION
apologies for my absence.

changes:
1. made the space below the text area dragable when in mobile mode, as the navigation section is not accessible in that state.
2. added synonyms and suggestions options. Most of the code was already there, there just wasn't anything to flip the switch.
3. removed some artifacts of my debugging
4. 'yes' and 'no' now work with Boolean options
5. changed the code for getting the previous marker to be symmetrical with the 'next marker' function. This means that if you get the prev marker when below the second marker, you will go to the second marker, not the first.
6. added 'replace' action. It takes two regex strings and replaces the first with the second, returning how many matches it found. Example: `> replace(true,false)`
