### PR TITLE
Tighten up build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,16 +5,16 @@
   "scripts": {
     "start": "electron .",
     "clean"        : "rm -r ~/Desktop/Left-darwin-x64/ ; rm -r ~/Desktop/Left-linux-x64/ ; rm -r ~/Desktop/Left-win32-x64/ ; echo 'cleaned build location'",
-    "build_osx"    : "electron-packager . Left --platform=darwin --arch=x64 --out ~/Desktop/ --overwrite --icon=icon.icns ; echo 'Built for OSX'",
-    "build_linux"  : "electron-packager . Left --platform=linux  --arch=x64 --out ~/Desktop/ --overwrite --icon=icon.ico ; echo 'Built for LINUX'",
-    "build_win"    : "electron-packager . Left --platform=win32  --arch=x64 --out ~/Desktop/ --overwrite --icon=icon.ico ; echo 'Built for WIN'",
+    "build_osx"    : "electron-packager . Left --platform=darwin --arch=x64 --out ~/Desktop/ --overwrite --icon=icon.icns && echo 'Built for OSX'",
+    "build_linux"  : "electron-packager . Left --platform=linux  --arch=x64 --out ~/Desktop/ --overwrite --icon=icon.ico && echo 'Built for LINUX'",
+    "build_win"    : "electron-packager . Left --platform=win32  --arch=x64 --out ~/Desktop/ --overwrite --icon=icon.ico && echo 'Built for WIN'",
     "build"        : "npm run clean ; npm run build_osx ; npm run build_linux ; npm run build_win",
     "push_osx"     : "~/butler push ~/Desktop/Left-darwin-x64/ hundredrabbits/left:osx-64",
     "push_linux"   : "~/butler push ~/Desktop/Left-linux-x64/ hundredrabbits/left:linux-64",
     "push_win"     : "~/butler push ~/Desktop/Left-win32-x64/ hundredrabbits/left:windows-64",
     "push_theme"   : "~/butler push ~/Github/HundredRabbits/Themes/themes/ hundredrabbits/left:themes",
     "push_status"  : "~/butler status hundredrabbits/left",
-    "push"         : "npm run build ; npm run push_theme ; npm run push_osx ; npm run push_linux ; npm run push_win ; npm run clean ; npm run push_status"
+    "push"         : "npm run build && npm run push_theme ; npm run push_osx ; npm run push_linux ; npm run push_win ; npm run clean ; npm run push_status"
   },
   "devDependencies": {
     "electron": "^1.8.1"


### PR DESCRIPTION
Adds `&&` instead of `;` to build commands in order to prevent execution of latter commands upon failure of a previous one. Not so important for the `echo`s, but very important for the `push`, which should not execute the push commands if `npm run build` fails.