### PR TITLE
Allow Open With and file association on Windows

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,5 +1,6 @@
 {
   "name": "Left",
+  "productName": "Left",
   "version": "0.1.0",
   "main": "main.js",
   "scripts": {

--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -30,6 +30,14 @@
       const app_path = app.getAppPath();
       
       var left = new Left(); left.start();
+
+      // On Windows: open the file specified in the first argument
+      // (allows Open With and file associations on Windows)
+      const remote = require('electron').remote;
+      if (process.platform === "win32" && remote.process.argv.length > 1) {
+        left.project.add(remote.process.argv[1]);
+      }
+      
     </script>
   </body>
 </html>


### PR DESCRIPTION
Now works:
- Right click on file / Open With / Left (first time: Look for another app on this pc / select Left.exe)
- If you check "Always use this app" Left will be the default app for that file type - allows for e.g. making Left the default app for .txt (or .left) files

