### PR TITLE
Fix prev/next file commands

### DIFF
--- a/desktop/sources/scripts/navi.js
+++ b/desktop/sources/scripts/navi.js
@@ -19,7 +19,7 @@ function Navi()
 
   this.project_markers = function()
   {
-    for(id in left.project.paths){
+    for(var id = 0; id < left.project.paths.length; id++){
       // Project markers
       var path = left.project.paths[id];
       var parts = path.replace(/\\/g,"/").split("/")
@@ -44,7 +44,7 @@ function Navi()
     var active_line_id = left.active_line_id();
     var i = 0;
     var marker_num = left.options.marker_num
-    for(marker_id in this.markers){
+    for(var marker_id = 0; marker_id < this.markers.length; marker_id++){
       var marker = this.markers[marker_id];
       var next_marker = this.markers[i+1];
       var el = document.createElement('li');

--- a/desktop/sources/scripts/project.js
+++ b/desktop/sources/scripts/project.js
@@ -122,12 +122,12 @@ function Project()
 
     this.paths.push(path);
     left.refresh();
-    this.next();
+    this.show_file(this.paths.length-1);
   }
 
   this.next = function()
   {
-    if(this.index > this.paths.length-1){ return; }
+    if(this.index >= this.paths.length-1){ return; }
 
     this.show_file(this.index+1);
     left.navi.update();
@@ -183,13 +183,13 @@ function Project()
   {
     if(this.has_changes() && !force){ left.project.alert(); return; }
 
-
-    var path = left.project.paths[left.project.index];
+    this.index = clamp(index,0,this.paths.length-1);
+    
+    var path = left.project.paths[this.index];
     var parts = path.replace(/\\/g,"/").split("/")
     var file_name = parts[parts.length-1];
 
     document.title = file_name ? `Left — ${file_name}` : "Left"
-    this.index = clamp(index,0,this.paths.length-1);
 
     this.load_path(this.paths[this.index]);
     left.navi.update();


### PR DESCRIPTION
The editor glitched when prev/next file shortcut or command was selected. There were some strange things happening with these for loops (id being string and not int) and later it would get fuckered in the project.js when trying to add or subtract 1 to move between files. This should fix it.

Includes some little fixes in project.js.

(Apparently iterating over arrays with for..in is not recommended...)