### PR TITLE
Minimize on Windows instead of hide

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -17,7 +17,11 @@ app.toggle_fullscreen = function()
 
 app.toggle_visible = function()
 {
-  if(is_shown){ app.win.hide(); } else{ app.win.show(); }
+  if(process.platform == "win32"){
+    if(!app.win.isMinimized()){ app.win.minimize(); } else{ app.win.restore(); }
+  } else {
+    if(is_shown){ app.win.hide(); } else{ app.win.show(); }
+  }
 }
 
 app.inject_menu = function(m)


### PR DESCRIPTION
Fixes #59

Restore does not really work, because minimized window does not receive shortcuts, but it's included in case `toggle_visible` is triggered in a different way.