### PR TITLE
Fix app name in Windows system menus (now for real)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -23,6 +23,6 @@
     "electron": "^1.8.1"
   },
   "dependencies": {
-    "electron-packager": "^8.4.0"
+    "electron-packager": "^12.0.1"
   }
 }


### PR DESCRIPTION
The old version of electron-packager was not setting the executable name.