### PR TITLE
Load files synchronously to prevent mismatched contents

### DIFF
--- a/desktop/sources/scripts/project.js
+++ b/desktop/sources/scripts/project.js
@@ -170,12 +170,16 @@ function Project()
   {
     if(!path){ this.original = left.textarea_el.value; return; }
 
-    fs.readFile(path, 'utf-8', (err, data) => {
-      if(err){ alert("An error ocurred reading the file :" + err.message); return; }
-      left.project.load(data,path);
-      left.scroll_to(0,0)
-      left.refresh();
-    });
+    var data;
+    try {
+      data = fs.readFileSync(path, 'utf-8');
+    } catch (err) {
+      alert("An error ocurred reading the file :" + err.message);
+      return;
+    }
+    left.project.load(data,path);
+    left.scroll_to(0,0);
+    left.refresh();
   }
 
   this.load = function(content,path)


### PR DESCRIPTION
When dropping multiple files into Left window, `readFile` callbacks are not always called in the original order and you might end up with file contents mismatched. If you make edits and save, the original content of the file will be overwritten. This fixes the problem.