### PR TITLE
Keybind to toggle navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 
 ### View
 - Toggle Dark Mode: `CmdOrCtrl+Shift+T`
+- Toggle Navigation: `CmdOrCtrl+\`
 
 ### Mode
 - Reader: `CmdOrCtrl+K`

--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <title>Left</title>
-    
+
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
 
@@ -15,7 +15,7 @@
 
     <script src="scripts/navi.js"></script>
     <script src="scripts/page.js"></script>
-    
+
     <script src="scripts/go.js"></script>
     <script src="scripts/insert.js"></script>
 
@@ -27,7 +27,7 @@
     <script src="scripts/operator.js"></script>
     <script src="scripts/left.js"></script>
     <script src="scripts/reader.js"></script>
-    
+
   </head>
   <body>
     <script>
@@ -38,8 +38,8 @@
       const {dialog,app} = require('electron').remote;
       const fs = require('fs');
       const app_path = app.getAppPath();
-      
-      var left = new Left(); 
+
+      var left = new Left();
       left.start();
 
       // Menu
@@ -81,6 +81,7 @@
       left.controller.add("default","Navigation","Prev Marker",() => { left.navi.prev_marker(); },"CmdOrCtrl+[");
 
       left.controller.add("default","View","Toggle Dark Mode",() => {  left.theme.toggle() },"CmdOrCtrl+Shift+T");
+      left.controller.add("default","View","Toggle Navigation",() => {  left.navi.toggle() },"CmdOrCtrl+\\");
 
       left.controller.add("default","Mode","Reader",() => { left.reader.start(); },"CmdOrCtrl+K");
       left.controller.add("default","Mode","Insert",() => { left.insert.start(); },"CmdOrCtrl+I");
@@ -140,7 +141,7 @@
       if (process.platform === "win32" && remote.process.argv.length > 1) {
         left.project.add(remote.process.argv[1]);
       }
-      
+
     </script>
   </body>
 </html>

--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -1,8 +1,9 @@
 @charset "utf-8";
 
 body { font-family: 'input_mono_regular'; font-size: 12px; overflow-y: hidden; transition: background-color 500ms; }
-body navi { display: block;width: calc((100vw / 4) - 40px);left: 0px;position: absolute;padding: 30px; -webkit-user-select: none;-webkit-app-region: drag; overflow-y: hidden; padding-top:90px;padding-bottom: 100px; transition: opacity 150ms, translateY 150ms; opacity:1; }
-body navi li { display: block;line-height: 20px;cursor: pointer; position: relative; -webkit-app-region: no-drag; }
+body navi { display: block;width: calc((100vw / 4) - 40px);left: 0px;position: absolute;padding: 30px; -webkit-user-select: none;-webkit-app-region: drag; overflow-y: hidden; padding-top:90px;padding-bottom: 100px; transition: opacity 500ms, translateY 150ms; opacity:1; }
+body navi li { display: flex; flex-direction: row; justify-content: space-between; align-items: center; line-height: 20px; cursor: pointer; position: relative; -webkit-app-region: no-drag; }
+body navi li span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 body navi li::before { position: absolute; left:-15px;}
 body navi li:hover { text-decoration: underline; }
 body navi li.page { font-family: 'input_mono_medium' }
@@ -12,13 +13,13 @@ body navi li.note { padding-left:15px;}
 body navi li.note::before { content:"#"; left:0px; }
 body navi li.comment {padding-left: 15px;}
 body navi li.comment::before { content:"-"; left:0px; }
-body navi li.changes::after { content:"*"; }
-body navi li i { float:right; padding-right:15px; }
+body navi li.changes::after { content:"*"; position: absolute; right: 15px; }
+body navi li i { padding-right:15px; }
 body stats { display: block;border-bottom: 0px;margin-top: 30px;position: fixed;bottom:0px;left: 25vw;line-height: 40px;width:calc(75vw - 40px);height:40px;overflow: hidden;-webkit-user-select: none;-webkit-app-region: drag;}
 body stats b {  font-family: 'input_mono_medium';}
 body stats i { text-decoration: underline; }
 body stats .right { float:right; }
-body textarea { padding: 90px 0px 0px;height: calc(100vh - 130px);display: block;width: 50vw;position: fixed;left: 25vw;line-height: 20px;resize: none;background: transparent;overflow: hidden;max-width: 600px; }
+body textarea { padding: 90px 0px 0px;height: calc(100vh - 130px);display: block;width: 50vw;position: fixed;left: 25vw;line-height: 20px;resize: none;background: transparent;overflow: hidden;max-width: 80%; }
 body div { max-width: 600px; width:50vw;line-height: 20px;font-family: 'input_mono_regular'; font-size: 12px;white-space: pre-wrap; word-wrap:break-word}
 body drag { display: block;width: 100vw;height: 40px;position: fixed;top: 0px;-webkit-user-select: none;-webkit-app-region: drag;}
 
@@ -26,9 +27,7 @@ body #operator { display: block;border-bottom: 0px;margin-top: 30px;position: fi
 body #operator.inactive { bottom:-40px; }
 body #operator.active { bottom:0px; }
 
-body.mobile navi { opacity:0; display: none; }
-body.mobile textarea { left: 30px;width: calc(100vw - 60px); }
-body.mobile stats { left: 30px; -webkit-app-region: drag; }
+body.mobile navi { opacity:0; }
 
 body #theme_button { width: 40px;height: 40px;position: fixed;right: 0px;bottom: 0px;overflow: hidden; cursor: pointer; opacity: 0; transition: opacity 500ms }
 body #theme_button_icon { border: 1px solid white;width: 10px;height: 10px;position: absolute;left: 14.5px;top: 14.5px;border-radius: 30px;overflow: hidden; }
@@ -38,7 +37,7 @@ body #theme_button:hover { opacity: 1 }
 
 /* Theme Defaults */
 
-:root { --background: "#222"; --f_high: "#fff";--f_med: "#777";--f_low: "#444";--f_inv: "#000";--b_high: "#000";--b_med: "#555";--b_low: "#000";--b_inv: "#aaa"; }  
+:root { --background: "#222"; --f_high: "#fff";--f_med: "#777";--f_low: "#444";--f_inv: "#000";--b_high: "#000";--b_med: "#555";--b_low: "#000";--b_inv: "#aaa"; }
 
 body { background:var(--background); color:var(--f_high) !important; }
 textarea { color:var(--f_high) !important }
@@ -60,4 +59,3 @@ body #theme_button_icon_fg { background-color: var(--f_med) !important }
 .fh { color:var(--f_high) !important; }
 .fm { color:var(--f_med) !important; }
 .fl { color:var(--f_low) !important; }
-

--- a/desktop/sources/scripts/events.js
+++ b/desktop/sources/scripts/events.js
@@ -5,10 +5,10 @@ document.onkeydown = function key_down(e)
   // Faster than Electron
   if(e.keyCode == 9){
     if(e.shiftKey){
-      left.select_synonym();   
+      left.select_synonym();
     }
     else{
-      left.select_autocomplete(); 
+      left.select_autocomplete();
     }
     e.preventDefault();
     return;
@@ -18,7 +18,7 @@ document.onkeydown = function key_down(e)
   if(e.key == " " || e.key == "Enter"){
     left.selection.index = 0;
   }
-  
+
   if(e.key.substring(0,5) == "Arrow"){
     setTimeout(() => left.refresh(), 0) //force the refresh event to happen after the selection updates
     return;
@@ -53,7 +53,7 @@ window.addEventListener('drop', function(e)
 {
   e.stopPropagation();
   e.preventDefault();
-  
+
   var files = e.dataTransfer.files;
 
   for(id in files){
@@ -76,16 +76,6 @@ document.addEventListener('wheel', function(e)
   left.stats.on_scroll()
   left.navi.on_scroll()
 }, false)
-
-window.addEventListener('resize', function(e)
-{
-  if(window.innerWidth < 800){
-    document.body.className = "mobile";
-  }
-  else{
-    document.body.className = "";
-  }
-}, false);
 
 document.onmouseup = function on_mouseup(e)
 {

--- a/desktop/sources/scripts/navi.js
+++ b/desktop/sources/scripts/navi.js
@@ -38,7 +38,7 @@ function Navi()
     var pos = left.active_line_id();
     var is_active = this.marker() && this.marker().line == marker.line;
 
-    el.innerHTML = `${marker.text}<i>${marker.line}</i>`;
+    el.innerHTML = `<span>${marker.text}</span><i>${marker.line}</i>`;
     el.className = `marker ${marker.type} ${is_active ? 'active' : ''}`
     el.onmouseup = function on_mouseup(e){ left.go.to_page(pid,marker.line); }
 
@@ -96,8 +96,13 @@ function Navi()
     var scroll_max = left.textarea_el.scrollHeight - left.textarea_el.offsetHeight;
     var scroll_perc = Math.min(1, (scroll_max == 0) ? 0 : (scroll_distance / scroll_max));
     var navi_overflow_perc = Math.max(0, (left.navi.el.scrollHeight / window.innerHeight) - 1);
-    
+
     left.navi.el.style.transform = "translateY(" + (-100 * scroll_perc * navi_overflow_perc) + "%)";
+  }
+
+  this.toggle = function()
+  {
+    document.body.classList.toggle('mobile');
   }
 
   function clamp(v, min, max) { return v < min ? min : v > max ? max : v; }


### PR DESCRIPTION
I was frustrated the navigation kept closing when working in a small window, with no way to retrieve it without increasing my window size. This pull request adds a keybind `CmdOrCtrl+\` to hide and show the navigation (Atom uses this keybind for their tree-view so it feels natural, at least to me).

To accommodate this, long named navigation items will be truncated with ellipsis when the text overflows in small windows.

This is a fairly opinionated change but I think it's an improvement. If you disagree, let me know!