### PR TITLE
Fill window space when navigation is hidden

### DIFF
--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -1,7 +1,7 @@
 @charset "utf-8";
 
 body { font-family: 'input_mono_regular'; font-size: 12px; overflow-y: hidden; transition: background-color 500ms; }
-body navi { display: block;width: calc((100vw / 4) - 40px);left: 0px;position: absolute;padding: 30px; -webkit-user-select: none;-webkit-app-region: drag; overflow-y: hidden; padding-top:90px;padding-bottom: 100px; transition: opacity 500ms, translateY 150ms; opacity:1; }
+body navi { display: block;width: calc((100vw / 4) - 40px);left: 0px;position: absolute;padding: 30px; -webkit-user-select: none;-webkit-app-region: drag; overflow-y: hidden; padding-top:90px;padding-bottom: 100px; transition: opacity 150ms, translateY 150ms; opacity:1; transition-delay: 150ms; }
 body navi li { display: flex; flex-direction: row; justify-content: space-between; align-items: center; line-height: 20px; cursor: pointer; position: relative; -webkit-app-region: no-drag; }
 body navi li span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 body navi li::before { position: absolute; left:-15px;}
@@ -15,11 +15,11 @@ body navi li.comment {padding-left: 15px;}
 body navi li.comment::before { content:"-"; left:0px; }
 body navi li.changes::after { content:"*"; position: absolute; right: 15px; }
 body navi li i { padding-right:15px; }
-body stats { display: block;border-bottom: 0px;margin-top: 30px;position: fixed;bottom:0px;left: 25vw;line-height: 40px;width:calc(75vw - 40px);height:40px;overflow: hidden;-webkit-user-select: none;-webkit-app-region: drag;}
+body stats { display: block;border-bottom: 0px;margin-top: 30px;position: fixed;bottom:0px;left: 25vw;line-height: 40px;width:calc(75vw - 40px);height:40px;overflow: hidden;-webkit-user-select: none;-webkit-app-region: drag; transition: left 200ms; }
 body stats b {  font-family: 'input_mono_medium';}
 body stats i { text-decoration: underline; }
 body stats .right { float:right; }
-body textarea { padding: 90px 0px 0px;height: calc(100vh - 130px);display: block;width: 50vw;position: fixed;left: 25vw;line-height: 20px;resize: none;background: transparent;overflow: hidden;max-width: 80%; }
+body textarea { padding: 90px 0px 0px;height: calc(100vh - 130px);display: block;width: 50vw;position: fixed;left: 25vw;line-height: 20px;resize: none;background: transparent;overflow: hidden;max-width: 90%; transition: left 200ms; }
 body div { max-width: 600px; width:50vw;line-height: 20px;font-family: 'input_mono_regular'; font-size: 12px;white-space: pre-wrap; word-wrap:break-word}
 body drag { display: block;width: 100vw;height: 40px;position: fixed;top: 0px;-webkit-user-select: none;-webkit-app-region: drag;}
 
@@ -27,7 +27,9 @@ body #operator { display: block;border-bottom: 0px;margin-top: 30px;position: fi
 body #operator.inactive { bottom:-40px; }
 body #operator.active { bottom:0px; }
 
-body.mobile navi { opacity:0; }
+body.mobile navi { opacity:0; transition: opacity 10ms; }
+body.mobile textarea { width: 100vw; left: 5%; transition: left 200ms; transition-delay: 20ms; }
+body.mobile stats { left: 5%; transition: left 200ms; transition-delay: 20ms; }
 
 body #theme_button { width: 40px;height: 40px;position: fixed;right: 0px;bottom: 0px;overflow: hidden; cursor: pointer; opacity: 0; transition: opacity 500ms }
 body #theme_button_icon { border: 1px solid white;width: 10px;height: 10px;position: absolute;left: 14.5px;top: 14.5px;border-radius: 30px;overflow: hidden; }

--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -1,7 +1,7 @@
 @charset "utf-8";
 
 body { font-family: 'input_mono_regular'; font-size: 12px; overflow-y: hidden; transition: background-color 500ms; }
-body navi { display: block;width: calc((100vw / 4) - 40px);left: 0px;position: absolute;padding: 30px; -webkit-user-select: none;-webkit-app-region: drag; overflow-y: hidden; padding-top:90px;padding-bottom: 100px; transition: opacity 150ms, translateY 150ms; opacity:1; transition-delay: 150ms; }
+body navi { display: block;width: calc((100vw / 4) - 40px);left: 0px;position: absolute;padding: 30px; -webkit-user-select: none;-webkit-app-region: drag; overflow-y: hidden; padding-top:90px;padding-bottom: 100px; transition: opacity 200ms 200ms, translateY 150ms, width 200ms; opacity:1; }
 body navi li { display: flex; flex-direction: row; justify-content: space-between; align-items: center; line-height: 20px; cursor: pointer; position: relative; -webkit-app-region: no-drag; }
 body navi li span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 body navi li::before { position: absolute; left:-15px;}

--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -29,7 +29,7 @@ body #operator.active { bottom:0px; }
 
 body.mobile navi { opacity:0; transition: opacity 10ms; }
 body.mobile textarea { width: 100vw; left: 5%; transition: left 200ms; transition-delay: 20ms; }
-body.mobile stats { left: 5%; transition: left 200ms; transition-delay: 20ms; }
+body.mobile stats { width: 85%; left: 5%; transition: left 200ms; transition-delay: 20ms; }
 
 body #theme_button { width: 40px;height: 40px;position: fixed;right: 0px;bottom: 0px;overflow: hidden; cursor: pointer; opacity: 0; transition: opacity 500ms }
 body #theme_button_icon { border: 1px solid white;width: 10px;height: 10px;position: absolute;left: 14.5px;top: 14.5px;border-radius: 30px;overflow: hidden; }


### PR DESCRIPTION
Fills the window space better when navigation is hidden, as suggested in https://github.com/hundredrabbits/Left/pull/84#issuecomment-414501682.

Also adds a nice, smooth animation when hiding the navigation and moving the text.

<img width="699" alt="screen shot 2018-08-20 at 7 23 00 pm" src="https://user-images.githubusercontent.com/34928425/44375034-d0d9ce80-a4ae-11e8-8c04-9bc2a9f67901.png">

Sorry for all the extra commits, still figuring out how to rebase and keep forks up-to-date 🙈