### PR TITLE
Decouple navigation and text scrolling

### DIFF
--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -1,7 +1,10 @@
 @charset "utf-8";
 
-body { font-family: 'input_mono_regular'; font-size: 12px; overflow-y: hidden; transition: background-color 500ms; }
-body navi { display: block;width: calc((100vw / 4) - 40px);left: 0px;position: absolute;padding: 30px; -webkit-user-select: none;-webkit-app-region: drag; overflow-y: hidden; padding-top:90px;padding-bottom: 100px; transition: opacity 200ms 200ms, translateY 150ms, width 200ms; opacity:1; }
+::-webkit-scrollbar { display: none; margin: 0; padding: 0; }
+body { font-family: 'input_mono_regular'; font-size: 12px; overflow: auto; transition: background-color 500ms; }
+body navi { display: block;width: calc((100vw / 4) - 40px);left: 0px;position: absolute;padding: 30px; -webkit-user-select: none;-webkit-app-region: drag;
+  overflow: auto;
+  padding-top:90px;transition: opacity 200ms 200ms, translateY 150ms, width 200ms; opacity:1; }
 body navi li { display: flex; flex-direction: row; justify-content: space-between; align-items: center; line-height: 20px; cursor: pointer; position: relative; -webkit-app-region: no-drag; }
 body navi li span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 body navi li::before { position: absolute; left:-15px;}
@@ -19,7 +22,7 @@ body stats { display: block;border-bottom: 0px;margin-top: 30px;position: fixed;
 body stats b {  font-family: 'input_mono_medium';}
 body stats i { text-decoration: underline; }
 body stats .right { float:right; }
-body textarea { padding: 90px 0px 0px;height: calc(100vh - 130px);display: block;width: 50vw;position: fixed;left: 25vw;line-height: 20px;resize: none;background: transparent;overflow: hidden;max-width: 90%; transition: left 200ms; }
+body textarea { padding: 90px 0px 0px;height: calc(100vh - 130px);display: block;width: 50vw;position: fixed;left: 25vw;line-height: 20px;resize: none;background: transparent;overflow: auto;max-width: 90%; transition: left 200ms; }
 body div { max-width: 600px; width:50vw;line-height: 20px;font-family: 'input_mono_regular'; font-size: 12px;white-space: pre-wrap; word-wrap:break-word}
 body drag { display: block;width: 100vw;height: 40px;position: fixed;top: 0px;-webkit-user-select: none;-webkit-app-region: drag;}
 

--- a/desktop/sources/scripts/events.js
+++ b/desktop/sources/scripts/events.js
@@ -69,14 +69,6 @@ window.addEventListener('drop', function(e)
   left.navi.next_page();
 });
 
-document.addEventListener('wheel', function(e)
-{
-  e.preventDefault();
-  left.textarea_el.scrollTop += e.wheelDeltaY * -0.25;
-  left.stats.on_scroll()
-  left.navi.on_scroll()
-}, false)
-
 document.onmouseup = function on_mouseup(e)
 {
   left.selection.index = 0;

--- a/desktop/sources/scripts/go.js
+++ b/desktop/sources/scripts/go.js
@@ -24,7 +24,7 @@ function Go()
 
     this.to(from,to)
   }
-  
+
   this.to = function(from,to)
   {
     if(left.textarea_el.setSelectionRange){
@@ -46,7 +46,7 @@ function Go()
   this.to_word = function(word,from = 0, tries = 0, starting_with = false, ending_with = false)
   {
     var target = word;
-    
+
     if(starting_with){ target = target.substr(0,target.length-1); }
     if(ending_with){ target = target.substr(1,target.length-1); }
 
@@ -100,14 +100,13 @@ function Go()
     var change = to - start;
     var currentTime = 0;
     var increment = 20;
-        
+
     var animate = function()
-    {        
+    {
       currentTime += increment;
       var val = Math.easeInOutQuad(currentTime, start, change, duration);
       element.scrollTop = val;
       left.stats.on_scroll();
-      left.navi.on_scroll();
       if(currentTime < duration){
         requestAnimationFrame(animate, increment);
       }


### PR DESCRIPTION
The coupled scrolling of the text and navigation is really really cool. However, in [cases like this](https://gfycat.com/VengefulDimCarp), the navigation is inaccessible and useless at the bottom of the document. In addition, events that change the position of the document (i.e. Command+Up) doesn't update the navigation position.

These things could obviously be fixed and improved, but I think it makes more sense to decouple the scrolling so that the navigation consistently allows document traversal. This pull request allows the navigation and the text to be scrolled independently.

Let me know if anyone disagrees. I'm happy to close this and improve the current scrolling behavior instead :)