### PR TITLE
Speed Reader and Synonym Improvements, Small Fixes

### DIFF
--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -23,7 +23,7 @@ body stats b {  font-family: 'input_mono_medium';}
 body stats i { text-decoration: underline; }
 body stats .right { float:right; }
 body textarea { padding: 90px 0px 0px;height: calc(100vh - 130px);display: block;width: 50vw;position: fixed;left: 25vw;line-height: 20px;resize: none;background: transparent;overflow: auto;max-width: 90%; transition: left 200ms; }
-body div { max-width: 600px; width:50vw;line-height: 20px;font-family: 'input_mono_regular'; font-size: 12px;white-space: pre-wrap; word-wrap:break-word}
+body div { left: 25vw; max-width: 90%; width:50vw; line-height: 20px; font-family: 'input_mono_regular'; font-size: 12px; white-space: pre-wrap; word-wrap:break-word; }
 body drag { display: block;width: 100vw;height: 40px;position: fixed;top: 0px;-webkit-user-select: none;-webkit-app-region: drag;}
 
 body #operator { display: block;border-bottom: 0px;margin-top: 30px;position: fixed;bottom: 0px;left: calc((100vw / 2) - 25%);line-height: 40px;width: 540px;height: 40px;overflow: hidden;-webkit-user-select: none;-webkit-app-region: no-drag; bottom:-40px; transition: bottom 150ms }
@@ -33,6 +33,7 @@ body #operator.active { bottom:0px; }
 body.mobile navi { opacity:0; transition: opacity 10ms; }
 body.mobile textarea { width: 100vw; left: 5%; transition: left 200ms; transition-delay: 20ms; }
 body.mobile stats { width: 85%; left: 5%; transition: left 200ms; transition-delay: 20ms; }
+body.mobile div { width: 100vw; }
 
 body #theme_button { width: 40px;height: 40px;position: fixed;right: 0px;bottom: 0px;overflow: hidden; cursor: pointer; opacity: 0; transition: opacity 500ms }
 body #theme_button_icon { border: 1px solid white;width: 10px;height: 10px;position: absolute;left: 14.5px;top: 14.5px;border-radius: 30px;overflow: hidden; }

--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -34,6 +34,7 @@ body.mobile navi { opacity:0; transition: opacity 10ms; }
 body.mobile textarea { width: 100vw; left: 5%; transition: left 200ms; transition-delay: 20ms; }
 body.mobile stats { width: 85%; left: 5%; transition: left 200ms; transition-delay: 20ms; }
 body.mobile div { width: 100vw; }
+body.mobile #operator { width: 85%; left: 5%; }
 
 body #theme_button { width: 40px;height: 40px;position: fixed;right: 0px;bottom: 0px;overflow: hidden; cursor: pointer; opacity: 0; transition: opacity 500ms }
 body #theme_button_icon { border: 1px solid white;width: 10px;height: 10px;position: absolute;left: 14.5px;top: 14.5px;border-radius: 30px;overflow: hidden; }

--- a/desktop/sources/scripts/go.js
+++ b/desktop/sources/scripts/go.js
@@ -106,7 +106,7 @@ function Go()
       currentTime += increment;
       var val = Math.easeInOutQuad(currentTime, start, change, duration);
       element.scrollTop = val;
-      left.stats.on_scroll();
+      if (left.controller.mode !== "reader") left.stats.on_scroll();
       if(currentTime < duration){
         requestAnimationFrame(animate, increment);
       }

--- a/desktop/sources/scripts/go.js
+++ b/desktop/sources/scripts/go.js
@@ -90,7 +90,7 @@ function Go()
     var div = document.createElement("div");
     div.innerHTML = text_val.slice(0,to);
     document.body.appendChild(div);
-    animate_scroll_to(left.textarea_el,div.offsetHeight - 60,500);
+    animate_scroll_to(left.textarea_el,div.offsetHeight - 60, 200);
     div.remove();
   }
 
@@ -99,14 +99,14 @@ function Go()
     var start = element.scrollTop;
     var change = to - start;
     var currentTime = 0;
-    var increment = 20;
+    var increment = 20; // Equal to line-height
 
     var animate = function()
     {
       currentTime += increment;
       var val = Math.easeInOutQuad(currentTime, start, change, duration);
       element.scrollTop = val;
-      if (left.controller.mode !== "reader") left.stats.on_scroll();
+      if (!left.reader.active) left.stats.on_scroll();
       if(currentTime < duration){
         requestAnimationFrame(animate, increment);
       }

--- a/desktop/sources/scripts/left.js
+++ b/desktop/sources/scripts/left.js
@@ -30,7 +30,7 @@ function Left()
   document.body.appendChild(this.drag_el);
   document.body.appendChild(this.operator.el);
   document.body.appendChild(this.theme.button);
-  
+
   document.body.className = window.location.hash.replace("#","");
 
   this.textarea_el.setAttribute("autocomplete","off");
@@ -47,6 +47,7 @@ function Left()
     this.dictionary.start();
 
     this.textarea_el.focus();
+    this.textarea_el.addEventListener('scroll', () => { this.stats.on_scroll(); });
 
     this.textarea_el.value = `${this.splash}`;
     this.textarea_el.setSelectionRange(0,0);
@@ -57,8 +58,8 @@ function Left()
 
   this.select_autocomplete = function()
   {
-    if(left.selection.word.trim() != "" && left.suggestion && left.suggestion.toLowerCase() != left.active_word().toLowerCase()){ 
-      left.autocomplete(); 
+    if(left.selection.word.trim() != "" && left.suggestion && left.suggestion.toLowerCase() != left.active_word().toLowerCase()){
+      left.autocomplete();
     }else{
       left.inject("\u00a0\u00a0")
     }
@@ -67,7 +68,7 @@ function Left()
   this.select_synonym = function()
   {
     if(left.synonyms){
-      left.replace_active_word_with(left.synonyms[left.selection.index % left.synonyms.length]); 
+      left.replace_active_word_with(left.synonyms[left.selection.index % left.synonyms.length]);
       left.stats.update();
       left.selection.index += 1;
     }
@@ -127,7 +128,7 @@ function Left()
   {
     var from = position - 1;
 
-    // Find beginning of word 
+    // Find beginning of word
     while(from > -1){
       char = this.textarea_el.value[from];
       if(!char || !char.match(/[a-z]/i)){
@@ -196,18 +197,18 @@ function Left()
     if(w.substr(0,1) == w.substr(0,1).toUpperCase()){
       word = word.substr(0,1).toUpperCase()+word.substr(1,word.length);
     }
-    
+
     this.textarea_el.setSelectionRange(l.from, l.to);
 
     document.execCommand('insertText', false, word);
-    
+
     this.textarea_el.focus();
   }
 
   this.replace_selection_with = function(characters)
   {
     document.execCommand('insertText', false, characters);
-    this.refresh();    
+    this.refresh();
   }
 
   this.replace_line = function(id, new_text, del = false) // optional arg for deleting the line, used in actions
@@ -217,7 +218,7 @@ function Left()
 
     let from = arrJoin.length-lineArr[id].length;
     let to = arrJoin.length;
-    
+
     //splicing the string
     let new_text_value = this.textarea_el.value.slice(0,del ? from-1: from) + new_text + this.textarea_el.value.slice(to)
 

--- a/desktop/sources/scripts/left.js
+++ b/desktop/sources/scripts/left.js
@@ -47,7 +47,9 @@ function Left()
     this.dictionary.start();
 
     this.textarea_el.focus();
-    this.textarea_el.addEventListener('scroll', () => { this.stats.on_scroll(); });
+    this.textarea_el.addEventListener('scroll', () => {
+      if (!this.reader.active) this.stats.on_scroll();
+    });
 
     this.textarea_el.value = `${this.splash}`;
     this.textarea_el.setSelectionRange(0,0);

--- a/desktop/sources/scripts/left.js
+++ b/desktop/sources/scripts/left.js
@@ -70,7 +70,7 @@ function Left()
     if(left.synonyms){
       left.replace_active_word_with(left.synonyms[left.selection.index % left.synonyms.length]);
       left.stats.update();
-      left.selection.index += 1;
+      left.selection.index = (left.selection.index + 1) % left.synonyms.length;
     }
   }
 

--- a/desktop/sources/scripts/project.js
+++ b/desktop/sources/scripts/project.js
@@ -102,7 +102,11 @@ function Project()
   {
     if(this.page().has_changes()){
       var response = dialog.showMessageBox(app.win, {
-        type: 'question', buttons: ['Yes', 'No'], title: 'Confirm', message: 'Are you sure you want to discard changes?'
+        type: 'question',
+        buttons: ['Yes', 'No'],
+        title: 'Confirm',
+        message: 'Are you sure you want to discard changes?',
+        icon: `${app.path()}/icon.png`
       });
       if(response !== 0){
         return;
@@ -127,7 +131,8 @@ function Project()
       type: 'question',
       buttons: ['Yes', 'No'],
       title: 'Confirm',
-      message: 'Are you sure you want to discard changes?'
+      message: 'Are you sure you want to discard changes?',
+      icon: `${app.path()}/icon.png`
     });
     if (response === 0) { // Runs the following if 'Yes' is clicked
       this.page().revert();

--- a/desktop/sources/scripts/project.js
+++ b/desktop/sources/scripts/project.js
@@ -1,5 +1,5 @@
 function Project()
-{  
+{
   this.pages = [new Page(`${new Splash()}`)]
 
   this.paths = [null];
@@ -43,7 +43,7 @@ function Project()
   }
 
   this.open = function()
-  {    
+  {
     console.log("Open Pages");
 
     var paths = dialog.showOpenDialog(app.win, {properties: ['openFile','multiSelections']});
@@ -80,8 +80,8 @@ function Project()
 
     var page = this.page()
     var path = dialog.showSaveDialog(app.win);
-    
-    if(!name){ console.log("Nothing to save"); return; }
+
+    if(!path){ console.log("Nothing to save"); return; }
 
     fs.writeFile(path, page.text, (err) => {
       if(err){ alert("An error ocurred creating the file "+ err.message); return; }
@@ -100,7 +100,7 @@ function Project()
 
   this.close = function()
   {
-    if(this.page().has_changes()){ 
+    if(this.page().has_changes()){
       var response = dialog.showMessageBox(app.win, {
         type: 'question', buttons: ['Yes', 'No'], title: 'Confirm', message: 'Are you sure you want to discard changes?'
       });
@@ -147,7 +147,7 @@ function Project()
   this.quit = function()
   {
     if(this.has_changes()){
-      this.quit_dialog();  
+      this.quit_dialog();
     }
     else{
       app.exit()

--- a/desktop/sources/scripts/reader.js
+++ b/desktop/sources/scripts/reader.js
@@ -4,6 +4,7 @@ function Reader()
   this.queue = [];
   this.index = 0;
   this.speed = 175;
+  this.active = false;
 
   this.start = function()
   {
@@ -19,6 +20,7 @@ function Reader()
     }
 
     left.controller.set("reader");
+    this.active = true;
     this.queue = this.segment.words;
     this.index = 0;
 
@@ -61,6 +63,7 @@ function Reader()
     this.segment = {from:0,to:0,text:"",words:[]};
     this.queue = [];
     this.index = 0;
+    this.active = false;
     left.operator.stop();
     left.refresh();
   }

--- a/desktop/sources/scripts/reader.js
+++ b/desktop/sources/scripts/reader.js
@@ -23,9 +23,7 @@ function Reader()
     this.index = 0;
 
     // Small delay before starting the reader
-    setTimeout(() => {
-      this.run();
-    }, 250);
+    setTimeout(() => { this.run(); }, 250);
   }
 
   this.alert = function(t)

--- a/desktop/sources/scripts/reader.js
+++ b/desktop/sources/scripts/reader.js
@@ -7,7 +7,6 @@ function Reader()
 
   this.start = function()
   {
-    left.controller.set("reader");
     this.segment.from = left.textarea_el.selectionStart
     this.segment.to = left.textarea_el.selectionEnd
     this.segment.text = left.textarea_el.value.substr(this.segment.from,this.segment.to - this.segment.from).replace(/\n/g," ")
@@ -19,9 +18,14 @@ function Reader()
       return;
     }
 
+    left.controller.set("reader");
     this.queue = this.segment.words;
     this.index = 0;
-    this.run();
+
+    // Small delay before starting the reader
+    setTimeout(() => {
+      this.run();
+    }, 250);
   }
 
   this.alert = function(t)
@@ -54,8 +58,6 @@ function Reader()
 
   this.stop = function()
   {
-    if(this.index == 0){ return; }
-    
     left.controller.set("default");
     this.segment = {from:0,to:0,text:"",words:[]};
     this.queue = [];

--- a/desktop/sources/scripts/reader.js
+++ b/desktop/sources/scripts/reader.js
@@ -50,6 +50,7 @@ function Reader()
 
     var range = words.splice(0,left.reader.index).join(" ").length;
     left.select(left.reader.segment.from,left.reader.segment.from+range);
+    left.go.scroll_to(left.reader.segment.from, range);
 
     setTimeout(left.reader.run,left.reader.speed);
   }

--- a/desktop/sources/scripts/stats.js
+++ b/desktop/sources/scripts/stats.js
@@ -8,7 +8,7 @@ function Stats()
       this.el.innerHTML = left.insert.status();
       return;
     }
-      
+
     if(left.textarea_el.selectionStart != left.textarea_el.selectionEnd){
       this.el.innerHTML = this._selection();
     }
@@ -19,7 +19,7 @@ function Stats()
       this.el.innerHTML = this._synonyms();
     }
     else if(left.selection.url){
-      this.el.innerHTML = this._url(); 
+      this.el.innerHTML = this._url();
     }
     else{
       this.el.innerHTML = this._default();
@@ -35,10 +35,11 @@ function Stats()
 
   this._synonyms = function()
   {
-    var html = `<b>${left.selection.word}</b> `
-    for(id in left.synonyms){
-      var synonym = left.synonyms[id]
-      html += id == left.selection.index ? `<i>${synonym}</i> ` : synonym+" ";
+    var underlinedSyn = left.synonyms[left.selection.index];
+    var html = `<b>${left.selection.word}</b> <i>${underlinedSyn}</i> `
+
+    for (i = left.selection.index + 1; i < left.synonyms.length; i += 1) {
+      html += `${left.synonyms[i]} `;
     }
     return html
   }
@@ -65,7 +66,7 @@ function Stats()
     var scroll_distance = left.textarea_el.scrollTop;
     var scroll_max = left.textarea_el.scrollHeight - left.textarea_el.offsetHeight;
     var scroll_perc = Math.min(1, (scroll_max == 0) ? 0 : (scroll_distance / scroll_max));
-  
+
     this.el.innerHTML = `${(scroll_perc * 100).toFixed(2)}%`
   }
 


### PR DESCRIPTION
More pull requests for you! Getting annoying yet? :>

### Speed Reader

- Add small delay of 200ms before starting the speed reader
- Prevent speed reader initialization if too few words selected. This fixes a bug that prevents users from exiting the reader mode. Also early exit so it's (immeasurably) faster!
- ✨ Automatically scroll the text to the appropriate position when using the speed reader.

### Synonyms

- Correctly update the synonym index to wrap at end of array
- ✨ Improve the synonym selector behaviour so that you can actually see previously off-screen synonyms.

### Misc

- Add app icon to discard and close dialogs
- Fixed operator styling on mobile view

---

As always, let me know if there are any conflicting opinions about certain behaviors. Happy to rework!