### PR TITLE
Dark/Light Toggle with CSS Filter

### DIFF
--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -1,7 +1,7 @@
 @charset "utf-8";
 
 ::-webkit-scrollbar { display: none; margin: 0; padding: 0; }
-body { font-family: 'input_mono_regular'; font-size: 12px; overflow: auto; transition: background-color 500ms; }
+body { height: 100vh; font-family: 'input_mono_regular'; font-size: 12px; overflow: auto; transition: background-color 500ms; transition: filter 150ms; }
 body navi { display: block;width: calc((100vw / 4) - 40px);left: 0px;position: absolute;padding: 30px; -webkit-user-select: none;-webkit-app-region: drag;
   overflow: auto;
   padding-top:90px;transition: opacity 200ms 200ms, translateY 150ms, width 200ms; opacity:1; }
@@ -29,6 +29,10 @@ body drag { display: block;width: 100vw;height: 40px;position: fixed;top: 0px;-w
 body #operator { display: block;border-bottom: 0px;margin-top: 30px;position: fixed;bottom: 0px;left: calc((100vw / 2) - 25%);line-height: 40px;width: 540px;height: 40px;overflow: hidden;-webkit-user-select: none;-webkit-app-region: no-drag; bottom:-40px; transition: bottom 150ms }
 body #operator.inactive { bottom:-40px; }
 body #operator.active { bottom:0px; }
+
+:root { background-color: #222; }
+* { background-color: inherit; }
+body.invert { filter: invert(1); transition: filter 150ms; }
 
 body.mobile navi { opacity:0; transition: opacity 10ms; }
 body.mobile textarea { width: 100vw; left: 5%; transition: left 200ms; transition-delay: 20ms; }

--- a/desktop/sources/scripts/lib/theme.js
+++ b/desktop/sources/scripts/lib/theme.js
@@ -11,9 +11,15 @@ function Theme()
 
   this.default = {meta:{}, data: { background: "#222", f_high: "#fff", f_med: "#777", f_low: "#444", f_inv: "#000", b_high: "#000", b_med: "#aaa", b_low: "#000", b_inv: "#aaa" }}
   this.active = this.default;
+  this.invert = "false";
 
   this.start = function()
   {
+    var inv = localStorage.getItem("invert");
+    if (inv === "true") {
+      this.invert = "true";
+      document.body.classList.add("invert");
+    }
     this.load(localStorage.theme ? localStorage.theme : this.default, this.default);
     window.addEventListener('dragover',this.drag_enter);
     window.addEventListener('drop', this.drag);
@@ -96,10 +102,15 @@ function Theme()
 
   this.toggle = function()
   {
-    var dark_mode = left.theme.button.className == "active" ? true : false;
-
-    left.theme.button.className = dark_mode ? "" : "active";
-    left.theme.load(dark_mode == true ? left.theme.collection.noir : left.theme.collection.pale)
+    if (this.invert === "true") {
+      this.invert = "false";
+      document.body.classList.remove("invert");
+    } else if (this.invert === "false") {
+      this.invert = "true";
+      document.body.classList.add("invert");
+    }
+    this.button.classList.toggle("active");
+    localStorage.setItem("invert", this.invert);
   }
 
   function is_json(text){ try{ JSON.parse(text); return true; } catch (error){ return false; } }


### PR DESCRIPTION
This pull request implements suggestion 3 in https://github.com/hundredrabbits/Themes/issues/12#issue-352654811 by applying a CSS filter to invert the color scheme. It is saved using localStorage and works with all ecosystem themes.

Examples:

<img width="2664" alt="ccc" src="https://user-images.githubusercontent.com/34928425/44420777-15f81200-a53c-11e8-8b7d-857290d753f4.png">

---

This may not be the best solution to the problem, but I like how simple it is. One CSS rule and done. Feel free to reject and we can pursue different options.