### PR TITLE
Find Improvements, Small Fixes

### DIFF
--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -130,7 +130,7 @@
       left.controller.add_role("operator","Edit","selectall");
 
       left.controller.add("operator","Find","Find",() => { left.operator.start("find: "); },"CmdOrCtrl+F");
-      left.controller.add("operator","Find","Find Next",() => { left.operator.find_next(); },"CmdOrCtrl+G");
+      left.controller.add("operator","Find","Find Next",() => { left.operator.find_next(); },"CmdOrCtrl+N");
       left.controller.add("operator","Operator","Stop",() => { left.operator.stop(); },"Esc");
 
       left.controller.commit();

--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -129,6 +129,8 @@
       left.controller.add_role("operator","Edit","delete");
       left.controller.add_role("operator","Edit","selectall");
 
+      left.controller.add("operator","Find","Find",() => { left.operator.start("find: "); },"CmdOrCtrl+F");
+      left.controller.add("operator","Find","Find Next",() => { left.operator.find_next(); },"CmdOrCtrl+G");
       left.controller.add("operator","Operator","Stop",() => { left.operator.stop(); },"Esc");
 
       left.controller.commit();

--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -38,7 +38,7 @@ body.mobile #operator { width: 85%; left: 5%; }
 
 body #theme_button { width: 40px;height: 40px;position: fixed;right: 0px;bottom: 0px;overflow: hidden; cursor: pointer; opacity: 0; transition: opacity 500ms }
 body #theme_button_icon { border: 1px solid white;width: 10px;height: 10px;position: absolute;left: 14.5px;top: 14.5px;border-radius: 30px;overflow: hidden; }
-body #theme_button_icon_fg { width: 20px;height: 6.5px;background: white;position: relative;left: -2px;top: -2px; transition: top 250ms; }
+body #theme_button_icon_fg { max-width: 20px; width: 20px;height: 6.5px;background: white;position: relative;left: -2px;top: -2px; transition: top 250ms; }
 body #theme_button.active #theme_button_icon_fg { top:5.5px; }
 body #theme_button:hover { opacity: 1 }
 

--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -26,7 +26,7 @@ body textarea { padding: 90px 0px 0px;height: calc(100vh - 130px);display: block
 body div { left: 25vw; max-width: 90%; width:50vw; line-height: 20px; font-family: 'input_mono_regular'; font-size: 12px; white-space: pre-wrap; word-wrap:break-word; }
 body drag { display: block;width: 100vw;height: 40px;position: fixed;top: 0px;-webkit-user-select: none;-webkit-app-region: drag;}
 
-body #operator { display: block;border-bottom: 0px;margin-top: 30px;position: fixed;bottom: 0px;left: calc((100vw / 2) - 25%);line-height: 40px;width: 540px;height: 40px;overflow: hidden;-webkit-user-select: none;-webkit-app-region: no-drag; bottom:-40px; transition: bottom 150ms }
+body #operator { display: block;border-bottom: 0px;margin-top: 30px;position: fixed;bottom: 0px;left: 25vw;;line-height: 40px;width:calc(75vw - 40px);height: 40px;overflow: hidden;-webkit-user-select: none;-webkit-app-region: no-drag; bottom:-40px; transition: bottom 150ms }
 body #operator.inactive { bottom:-40px; }
 body #operator.active { bottom:0px; }
 

--- a/desktop/sources/scripts/events.js
+++ b/desktop/sources/scripts/events.js
@@ -69,7 +69,7 @@ window.addEventListener('drop', function(e)
   left.navi.next_page();
 });
 
-document.onmouseup = function on_mouseup(e)
+document.onclick = function on_click(e) =>
 {
   left.selection.index = 0;
   left.operator.stop();

--- a/desktop/sources/scripts/events.js
+++ b/desktop/sources/scripts/events.js
@@ -69,7 +69,7 @@ window.addEventListener('drop', function(e)
   left.navi.next_page();
 });
 
-document.onclick = function on_click(e) =>
+document.onclick = function on_click(e)
 {
   left.selection.index = 0;
   left.operator.stop();

--- a/desktop/sources/scripts/left.js
+++ b/desktop/sources/scripts/left.js
@@ -280,8 +280,8 @@ function Left()
 
   this.find = function(word)
   {
-    var text = left.textarea_el.value;
-    var parts = text.split(word);
+    var text = left.textarea_el.value.toLowerCase();
+    var parts = text.split(word.toLowerCase());
     var a = [];
     var sum = 0;
 

--- a/desktop/sources/scripts/lib/theme.js
+++ b/desktop/sources/scripts/lib/theme.js
@@ -84,7 +84,7 @@ function Theme()
 
   this.button = document.createElement("a");
   this.button.id = "theme_button";
-  this.button.onmouseup = function on_mouseup(e){ left.theme.toggle(); }
+  this.button.onclick = function on_click(e) { left.theme.toggle(); }
 
   this.button_icon = document.createElement("div");
   this.button_icon.id = "theme_button_icon";

--- a/desktop/sources/scripts/navi.js
+++ b/desktop/sources/scripts/navi.js
@@ -26,7 +26,8 @@ function Navi()
 
     el.textContent = page.name();
     el.className = `page ${is_active ? 'active' : ''} ${has_changes ? 'changes' : ''}`
-    el.onmouseup = function on_mouseup(e){ left.go.to_page(id); }
+    // el.onmouseup = function on_mouseup(e){ left.go.to_page(id); }
+    el.onclick = (e) => { left.go.to_page(id); }
 
     return el;
   }
@@ -40,7 +41,7 @@ function Navi()
 
     el.innerHTML = `<span>${marker.text}</span><i>${marker.line}</i>`;
     el.className = `marker ${marker.type} ${is_active ? 'active' : ''}`
-    el.onmouseup = function on_mouseup(e){ left.go.to_page(pid,marker.line); }
+    el.onclick = function on_click(e) { left.go.to_page(pid, marker.line); }
 
     return el;
   }

--- a/desktop/sources/scripts/operator.js
+++ b/desktop/sources/scripts/operator.js
@@ -24,7 +24,7 @@ function Operator()
   this.stop = function()
   {
     if(!this.is_active){ return; }
-    
+
     console.log("stopped")
     left.controller.set("default");
     this.is_active = false;
@@ -46,7 +46,7 @@ function Operator()
       e.preventDefault();
       return;
     }
-    
+
     if(!down && (e.key == "Enter" || e.code == "Enter")){
       this.active();
     }
@@ -141,11 +141,11 @@ function Operator()
 
   this.goto = function(q,bang = false)
   {
-    var target = parseInt(q);
+    var target = parseInt(q, 10);
 
-    if(q == "" || target < 1){ return; }
+    if(q == "" || target < 1 || Number.isNaN(target)) { return; }
 
-    if(bang){
+    if(bang) {
       this.stop();
       left.go.to_line(target);
     }

--- a/desktop/sources/scripts/operator.js
+++ b/desktop/sources/scripts/operator.js
@@ -90,6 +90,15 @@ function Operator()
     this[cmd](params,true);
   }
 
+  this.find_next = function()
+  {
+    if (!this.prev || !this.prev.includes("find:")) { return; }
+    var word = this.prev.replace("find:", "").trim();
+
+    // Find next occurence
+    this.find(word, true);
+  }
+
   this.find = function(q,bang = false)
   {
     if(q.length < 3){ return; }
@@ -105,9 +114,15 @@ function Operator()
       if(result > from){ break; }
     }
 
+    // Found final occurence, start from the top
+    if (result === left.textarea_el.selectionStart) {
+      left.textarea_el.setSelectionRange(0, 0);
+      this.find(q, true);
+      return;
+    }
+
     if(bang && result){
       left.go.to(result,result+q.length);
-      this.stop();
     }
   }
 
@@ -143,7 +158,11 @@ function Operator()
   {
     var target = parseInt(q, 10);
 
-    if(q == "" || target < 1 || Number.isNaN(target)) { return; }
+    var lines_count = left.textarea_el.value.split("\n").length - 1;
+
+    if(q == "" || target < 1 || target > lines_count || Number.isNaN(target)) {
+      return;
+    }
 
     if(bang) {
       this.stop();

--- a/desktop/sources/scripts/reader.js
+++ b/desktop/sources/scripts/reader.js
@@ -52,7 +52,7 @@ function Reader()
 
     var range = words.splice(0,left.reader.index).join(" ").length;
     left.select(left.reader.segment.from,left.reader.segment.from+range);
-    left.go.scroll_to(left.reader.segment.from, range);
+    left.go.scroll_to(0, left.reader.segment.from + range);
 
     setTimeout(left.reader.run,left.reader.speed);
   }

--- a/desktop/sources/scripts/stats.js
+++ b/desktop/sources/scripts/stats.js
@@ -12,11 +12,11 @@ function Stats()
     if(left.textarea_el.selectionStart != left.textarea_el.selectionEnd){
       this.el.innerHTML = this._selection();
     }
-    else if(left.selection.word && left.suggestion){
-      this.el.innerHTML = this._suggestion();
-    }
     else if(left.synonyms){
       this.el.innerHTML = this._synonyms();
+    }
+    else if(left.selection.word && left.suggestion){
+      this.el.innerHTML = this._suggestion();
     }
     else if(left.selection.url){
       this.el.innerHTML = this._url();


### PR DESCRIPTION
- Type check operator goto input to ensure it is an integer. (fixes type error)
- Ensure inputted goto integer is not longer than the number of lines in the text.
- Replace on_mouseup event listeners with onclick (generally better practice, fixes glitch when selecting text and accidentally triggering mouseup on a navigation link)
- Fix the styling of the theme button that I broke while making speed reader changes.
- Synonyms will now appear after typing a word, instead of suggestions (before, typing `simple|` with cursor at the end of the word would only show suggestions, now it shows synonyms). This also fixes a bug where you could cycle between synonyms but they wouldn't be shown in the stats.
- Find will now search case-insensitive-ly.
- ✨ In operator find mode, there is now a keybind `CmdOrCtrl+N` to cycle through all of the occurrences of the searched word.