### PR TITLE
Fix linting errors, improve modules

### DIFF
--- a/desktop/.eslintrc.json
+++ b/desktop/.eslintrc.json
@@ -6,5 +6,8 @@
     },
     "plugins": [
       "html"
-    ]
+    ],
+    "globals": {
+      "left": true
+    }
 }

--- a/desktop/.eslintrc.json
+++ b/desktop/.eslintrc.json
@@ -3,5 +3,8 @@
     "env": {
       "browser": true,
       "node": true
-    }
+    },
+    "plugins": [
+      "html"
+    ]
 }

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,11 +1,9 @@
-const { app, BrowserWindow, webFrame, Menu, dialog } = require('electron')
+const { app, Menu, BrowserWindow } = require('electron')
 const path = require('path')
-const url = require('url')
-const shell = require('electron').shell
 
-let is_shown = true
+let isShown = true
 
-app.on('ready', () => {
+function createWindow () {
   app.win = new BrowserWindow({
     width: 880,
     height: 530,
@@ -14,36 +12,49 @@ app.on('ready', () => {
     minHeight: 540,
     frame: false,
     autoHideMenuBar: true,
-    icon: __dirname + '/icon.ico'
+    icon: path.join(__dirname, '/icon.ico')
+  })
+
+  const { webContents } = app.win
+  webContents.on('did-finish-load', () => {
+    webContents.setZoomFactor(1)
+    webContents.setVisualZoomLevelLimits(1, 1)
+    webContents.setLayoutZoomLevelLimits(0, 0)
   })
 
   app.win.loadURL(`file://${__dirname}/sources/index.html`)
+
+  // Uncomment to show devTools on load
   // app.inspect();
 
   app.win.on('closed', () => {
-    win = null
+    app.win = null
     app.quit()
   })
 
   app.win.on('hide', () => {
-    is_shown = false
+    isShown = false
   })
 
   app.win.on('show', () => {
-    is_shown = true
+    isShown = true
   })
+}
 
-  app.on('window-all-closed', () => {
-    app.quit()
-  })
+app.on('ready', () => {
+  createWindow()
+})
 
-  app.on('activate', () => {
-    if (app.win === null) {
-      createWindow()
-    } else {
-      app.win.show()
-    }
-  })
+app.on('window-all-closed', () => {
+  app.quit()
+})
+
+app.on('activate', () => {
+  if (app.win === null) {
+    createWindow()
+  } else {
+    app.win.show()
+  }
 })
 
 // Helpers
@@ -57,10 +68,10 @@ app.toggle_fullscreen = function () {
 }
 
 app.toggle_visible = function () {
-  if (process.platform == 'win32') {
+  if (process.platform === 'win32') {
     if (!app.win.isMinimized()) { app.win.minimize() } else { app.win.restore() }
   } else {
-    if (is_shown && !app.win.isFullScreen()) { app.win.hide() } else { app.win.show() }
+    if (isShown && !app.win.isFullScreen()) { app.win.hide() } else { app.win.show() }
   }
 }
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -593,6 +593,49 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -776,6 +819,12 @@
         }
       }
     },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+      "dev": true
+    },
     "env-paths": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
@@ -939,6 +988,15 @@
       "requires": {
         "eslint-utils": "^1.3.0",
         "regexpp": "^2.0.0"
+      }
+    },
+    "eslint-plugin-html": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-4.0.6.tgz",
+      "integrity": "sha512-nj6A9oK+7BKnMm0E7dMRH3r75BfpkXtcVIb3pFC4AcDdBTNyg2NGxHXyFNT1emW4VsR7P2SZvRXXQtUR+kY08w==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^3.8.2"
       }
     },
     "eslint-plugin-import": {
@@ -1553,6 +1611,52 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "http-signature": {
       "version": "1.2.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "lint": "eslint --ignore-path ../.gitignore .",
+    "lint": "eslint --ignore-path ../.gitignore . --ext .html,.js",
     "clean": "rm -r ~/Desktop/Left-darwin-x64/ ; rm -r ~/Desktop/Left-linux-x64/ ; rm -r ~/Desktop/Left-win32-x64/ ; rm -r ~/Desktop/Left-linux-armv7l ; echo 'cleaned build location'",
     "build_osx": "electron-packager . Left --platform=darwin --arch=x64 --out ~/Desktop/ --overwrite --icon=icon.icns && echo 'Built for OSX'",
     "build_linux": "electron-packager . Left --platform=linux  --arch=x64 --out ~/Desktop/ --overwrite --icon=icon.ico && echo 'Built for LINUX'",
@@ -23,6 +23,7 @@
     "electron-packager": "^12.1.1",
     "eslint": "^5.6.1",
     "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-html": "^4.0.6",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-promise": "^4.0.1",

--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -48,7 +48,6 @@
       left.controller.add("default","*","About",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Left'); },"CmdOrCtrl+,");
       left.controller.add("default","*","Fullscreen",() => { app.toggle_fullscreen(); },"CmdOrCtrl+Enter");
       left.controller.add("default","*","Hide",() => { app.toggle_visible(); },"CmdOrCtrl+H");
-      left.controller.add("default","*","Inspect",() => { app.inspect(); },"CmdOrCtrl+.");
       left.controller.add("default","*","Reset",() => { left.reset(); },"CmdOrCtrl+Backspace");
       left.controller.add("default","*","Quit",() => { left.project.quit(); },"CmdOrCtrl+Q");
 
@@ -81,8 +80,10 @@
       left.controller.add("default","Navigation","Next Marker",() => { left.navi.next_marker(); },"CmdOrCtrl+]");
       left.controller.add("default","Navigation","Prev Marker",() => { left.navi.prev_marker(); },"CmdOrCtrl+[");
 
-      left.controller.add("default","View","Toggle Dark Mode",() => {  left.theme.toggle() },"CmdOrCtrl+Shift+T");
       left.controller.add("default","View","Toggle Navigation",() => {  left.navi.toggle() },"CmdOrCtrl+\\");
+      left.controller.add_role("default","View","reload");
+      left.controller.add_role("default","View","forcereload");
+      left.controller.add_role("default","View","toggledevtools");
 
       left.controller.add("default","Mode","Reader",() => { left.reader.start(); },"CmdOrCtrl+K");
       left.controller.add("default","Mode","Insert",() => { left.insert.start(); },"CmdOrCtrl+I");

--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -10,38 +10,26 @@
     <link rel="stylesheet" href="links/main.css"/>
     <link rel="stylesheet" href="links/theme.css"/>
 
-    <script src="scripts/splash.js"></script>
-    <script src="scripts/lib/theme.js"></script>
-    <script src="scripts/lib/controller.js"></script>
-
-    <script src="scripts/navi.js"></script>
-    <script src="scripts/page.js"></script>
-
-    <script src="scripts/go.js"></script>
-    <script src="scripts/insert.js"></script>
-
-    <script src="scripts/stats.js"></script>
-    <script src="scripts/project.js"></script>
     <script src="scripts/events.js"></script>
-    <script src="scripts/synonyms.js"></script>
-    <script src="scripts/dictionary.js"></script>
-    <script src="scripts/operator.js"></script>
-    <script src="scripts/left.js"></script>
-    <script src="scripts/reader.js"></script>
-
   </head>
   <body>
     <script>
       "use strict";
 
-      const { dialog, app } = require('electron').remote;
-      const fs = require('fs');
-      const app_path = app.getAppPath();
+      const { remote } = require('electron')
+      const Left = require('./left');
+      const { app } = remote
 
       const left = new Left();
 
       left.install(document.body);
       left.start();
+
+      // On Windows: open the file specified in the first argument
+      // (allows Open With and file associations on Windows)
+      if (process.platform === "win32" && remote.process.argv.length > 1) {
+        left.project.add(remote.process.argv[1]);
+      }
 
       // Menu
 
@@ -96,7 +84,6 @@
       left.controller.add("reader","*","About",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Left'); },"CmdOrCtrl+,");
       left.controller.add("reader","*","Fullscreen",() => { app.toggle_fullscreen(); },"CmdOrCtrl+Enter");
       left.controller.add("reader","*","Hide",() => { app.toggle_visible(); },"CmdOrCtrl+H");
-      left.controller.add("reader","*","Inspect",() => { app.inspect(); },"CmdOrCtrl+.");
       left.controller.add("reader","*","Reset",() => { left.theme.reset(); },"CmdOrCtrl+Backspace");
       left.controller.add("reader","*","Quit",() => { left.project.quit(); },"CmdOrCtrl+Q");
       left.controller.add("reader","Reader","Stop",() => { left.reader.stop(); },"Esc");
@@ -104,14 +91,12 @@
       left.controller.add("operator","*","About",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Left'); },"CmdOrCtrl+,");
       left.controller.add("operator","*","Fullscreen",() => { app.toggle_fullscreen(); },"CmdOrCtrl+Enter");
       left.controller.add("operator","*","Hide",() => { app.toggle_visible(); },"CmdOrCtrl+H");
-      left.controller.add("operator","*","Inspect",() => { app.inspect(); },"CmdOrCtrl+.");
       left.controller.add("operator","*","Reset",() => { left.theme.reset(); },"CmdOrCtrl+Backspace");
       left.controller.add("operator","*","Quit",() => { left.project.quit(); },"CmdOrCtrl+Q");
 
       left.controller.add("insert","*","About",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Left'); },"CmdOrCtrl+,");
       left.controller.add("insert","*","Fullscreen",() => { app.toggle_fullscreen(); },"CmdOrCtrl+Enter");
       left.controller.add("insert","*","Hide",() => { app.toggle_visible(); },"CmdOrCtrl+H");
-      left.controller.add("insert","*","Inspect",() => { app.inspect(); },"CmdOrCtrl+.");
       left.controller.add("insert","*","Reset",() => { left.theme.reset(); },"CmdOrCtrl+Backspace");
       left.controller.add("insert","*","Quit",() => { left.project.quit(); },"CmdOrCtrl+Q");
 
@@ -138,15 +123,6 @@
       left.controller.add("operator","Operator","Stop",() => { left.operator.stop(); },"Esc");
 
       left.controller.commit();
-
-      // On Windows: open the file specified in the first argument
-      // (allows Open With and file associations on Windows)
-
-      const remote = require('electron').remote;
-
-      if(process.platform === "win32" && remote.process.argv.length > 1){
-        left.project.add(remote.process.argv[1]);
-      }
 
     </script>
   </body>

--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -33,17 +33,13 @@
   <body>
     <script>
       "use strict";
-      
-      const {webFrame} = require('electron')
 
-      webFrame.setZoomLevelLimits(1, 1);
-
-      const {dialog,app} = require('electron').remote;
+      const { dialog, app } = require('electron').remote;
       const fs = require('fs');
       const app_path = app.getAppPath();
 
       const left = new Left();
-      
+
       left.install(document.body);
       left.start();
 

--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -14,116 +14,116 @@
   </head>
   <body>
     <script>
-      "use strict";
+      'use strict'
 
-      const { remote } = require('electron')
-      const Left = require('./left');
+      const { shell, remote } = require('electron')
+      const Left = require('./left')
       const { app } = remote
+      const EOL = '\n'
 
-      const left = new Left();
+      const left = new Left()
 
-      left.install(document.body);
-      left.start();
+      left.install(document.body)
+      left.start()
 
       // On Windows: open the file specified in the first argument
       // (allows Open With and file associations on Windows)
-      if (process.platform === "win32" && remote.process.argv.length > 1) {
-        left.project.add(remote.process.argv[1]);
+      if (process.platform === 'win32' && remote.process.argv.length > 1) {
+        left.project.add(remote.process.argv[1])
       }
 
       // Menu
 
-      left.controller.add("default","*","About",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Left'); },"CmdOrCtrl+,");
-      left.controller.add("default","*","Fullscreen",() => { app.toggle_fullscreen(); },"CmdOrCtrl+Enter");
-      left.controller.add("default","*","Hide",() => { app.toggle_visible(); },"CmdOrCtrl+H");
-      left.controller.add("default","*","Reset",() => { left.reset(); },"CmdOrCtrl+Backspace");
-      left.controller.add("default","*","Quit",() => { left.project.quit(); },"CmdOrCtrl+Q");
+      left.controller.add('default', '*', 'About', () => { shell.openExternal('https://github.com/hundredrabbits/Left') }, 'CmdOrCtrl+,')
+      left.controller.add('default', '*', 'Fullscreen', () => { app.toggle_fullscreen() }, 'CmdOrCtrl+Enter')
+      left.controller.add('default', '*', 'Hide', () => { app.toggle_visible() }, 'CmdOrCtrl+H')
+      left.controller.add('default', '*', 'Reset', () => { left.reset() }, 'CmdOrCtrl+Backspace')
+      left.controller.add('default', '*', 'Quit', () => { left.project.quit() }, 'CmdOrCtrl+Q')
 
-      left.controller.add("default","File","New",() => { left.project.new(); },"CmdOrCtrl+N");
-      left.controller.add("default","File","Open",() => { left.project.open(); },"CmdOrCtrl+O");
-      left.controller.add("default","File","Save",() => { left.project.save(); },"CmdOrCtrl+S");
-      left.controller.add("default","File","Save As",() => { left.project.save_as(); },"CmdOrCtrl+Shift+S");
-      left.controller.add("default","File","Discard Changes",() => { left.project.discard(); },"CmdOrCtrl+D");
-      left.controller.add("default","File","Close File",() => { left.project.close(); },"CmdOrCtrl+W");
-      left.controller.add("default","File","Force Close",() => { left.project.force_close(); },"CmdOrCtrl+Shift+W");
+      left.controller.add('default', 'File', 'New', () => { left.project.new() }, 'CmdOrCtrl+N')
+      left.controller.add('default', 'File', 'Open', () => { left.project.open() }, 'CmdOrCtrl+O')
+      left.controller.add('default', 'File', 'Save', () => { left.project.save() }, 'CmdOrCtrl+S')
+      left.controller.add('default', 'File', 'Save As', () => { left.project.save_as() }, 'CmdOrCtrl+Shift+S')
+      left.controller.add('default', 'File', 'Discard Changes', () => { left.project.discard() }, 'CmdOrCtrl+D')
+      left.controller.add('default', 'File', 'Close File', () => { left.project.close() }, 'CmdOrCtrl+W')
+      left.controller.add('default', 'File', 'Force Close', () => { left.project.force_close() }, 'CmdOrCtrl+Shift+W')
 
-      left.controller.add_role("default","Edit","undo");
-      left.controller.add_role("default","Edit","redo");
-      left.controller.add_role("default","Edit","cut");
-      left.controller.add_role("default","Edit","copy");
-      left.controller.add_role("default","Edit","paste");
-      left.controller.add_role("default","Edit","delete");
-      left.controller.add_role("default","Edit","selectall");
-      left.controller.add("default","Edit","Add Linebreak",() => { left.go.to_next(EOL,false); left.inject(EOL); },"CmdOrCtrl+Shift+Enter");
+      left.controller.add_role('default', 'Edit', 'undo')
+      left.controller.add_role('default', 'Edit', 'redo')
+      left.controller.add_role('default', 'Edit', 'cut')
+      left.controller.add_role('default', 'Edit', 'copy')
+      left.controller.add_role('default', 'Edit', 'paste')
+      left.controller.add_role('default', 'Edit', 'delete')
+      left.controller.add_role('default', 'Edit', 'selectall')
+      left.controller.add('default', 'Edit', 'Add Linebreak', () => { left.go.to_next(EOL, false); left.inject(EOL) }, 'CmdOrCtrl+Shift+Enter')
 
-      left.controller.add("default","Select","Select Autocomplete",() => { left.select_autocomplete(); },"Tab");
-      left.controller.add("default","Select","Select Synonym",() => { left.select_synonym(); },"Shift+Tab");
-      left.controller.add("default","Select","Find",() => { left.operator.start("find: "); },"CmdOrCtrl+F");
-      left.controller.add("default","Select","Replace",() => { left.operator.start("replace: a -> b"); },"CmdOrCtrl+Shift+F");
-      left.controller.add("default","Select","Goto",() => { left.operator.start("goto: "); },"CmdOrCtrl+G");
-      left.controller.add("default","Select","Open Url",() => { left.open_url(); },"CmdOrCtrl+B");
+      left.controller.add('default', 'Select', 'Select Autocomplete', () => { left.select_autocomplete() }, 'Tab')
+      left.controller.add('default', 'Select', 'Select Synonym', () => { left.select_synonym() }, 'Shift+Tab')
+      left.controller.add('default', 'Select', 'Find', () => { left.operator.start('find: ') }, 'CmdOrCtrl+F')
+      left.controller.add('default', 'Select', 'Replace', () => { left.operator.start('replace: a -> b') }, 'CmdOrCtrl+Shift+F')
+      left.controller.add('default', 'Select', 'Goto', () => { left.operator.start('goto: ') }, 'CmdOrCtrl+G')
+      left.controller.add('default', 'Select', 'Open Url', () => { left.open_url() }, 'CmdOrCtrl+B')
 
-      left.controller.add("default","Navigation","Next File",() => { left.navi.next_page(); },"CmdOrCtrl+Shift+]");
-      left.controller.add("default","Navigation","Prev File",() => { left.navi.prev_page(); },"CmdOrCtrl+Shift+[");
-      left.controller.add("default","Navigation","Next Marker",() => { left.navi.next_marker(); },"CmdOrCtrl+]");
-      left.controller.add("default","Navigation","Prev Marker",() => { left.navi.prev_marker(); },"CmdOrCtrl+[");
+      left.controller.add('default', 'Navigation', 'Next File', () => { left.navi.next_page() }, 'CmdOrCtrl+Shift+]')
+      left.controller.add('default', 'Navigation', 'Prev File', () => { left.navi.prev_page() }, 'CmdOrCtrl+Shift+[')
+      left.controller.add('default', 'Navigation', 'Next Marker', () => { left.navi.next_marker() }, 'CmdOrCtrl+]')
+      left.controller.add('default', 'Navigation', 'Prev Marker', () => { left.navi.prev_marker() }, 'CmdOrCtrl+[')
 
-      left.controller.add("default","View","Toggle Navigation",() => {  left.navi.toggle() },"CmdOrCtrl+\\");
-      left.controller.add_role("default","View","reload");
-      left.controller.add_role("default","View","forcereload");
-      left.controller.add_role("default","View","toggledevtools");
+      left.controller.add('default', 'View', 'Toggle Navigation', () => { left.navi.toggle() }, 'CmdOrCtrl+\\')
+      left.controller.add_role('default', 'View', 'reload')
+      left.controller.add_role('default', 'View', 'forcereload')
+      left.controller.add_role('default', 'View', 'toggledevtools')
 
-      left.controller.add("default","Mode","Reader",() => { left.reader.start(); },"CmdOrCtrl+K");
-      left.controller.add("default","Mode","Insert",() => { left.insert.start(); },"CmdOrCtrl+I");
+      left.controller.add('default', 'Mode', 'Reader', () => { left.reader.start() }, 'CmdOrCtrl+K')
+      left.controller.add('default', 'Mode', 'Insert', () => { left.insert.start() }, 'CmdOrCtrl+I')
 
-      left.controller.add("default","Theme","Noir",() => { left.theme.noir(); },"CmdOrCtrl+Shift+1");
-      left.controller.add("default","Theme","Pale",() => { left.theme.pale(); },"CmdOrCtrl+Shift+2");
-      left.controller.add("default","Theme","Invert",() => { left.theme.invert(); },"CmdOrCtrl+Shift+I");
-      left.controller.add("default","Theme","Install",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Themes'); });
+      left.controller.add('default', 'Theme', 'Noir', () => { left.theme.noir() }, 'CmdOrCtrl+Shift+1')
+      left.controller.add('default', 'Theme', 'Pale', () => { left.theme.pale() }, 'CmdOrCtrl+Shift+2')
+      left.controller.add('default', 'Theme', 'Invert', () => { left.theme.invert() }, 'CmdOrCtrl+Shift+I')
+      left.controller.add('default', 'Theme', 'Install', () => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Themes') })
 
-      left.controller.add("reader","*","About",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Left'); },"CmdOrCtrl+,");
-      left.controller.add("reader","*","Fullscreen",() => { app.toggle_fullscreen(); },"CmdOrCtrl+Enter");
-      left.controller.add("reader","*","Hide",() => { app.toggle_visible(); },"CmdOrCtrl+H");
-      left.controller.add("reader","*","Reset",() => { left.theme.reset(); },"CmdOrCtrl+Backspace");
-      left.controller.add("reader","*","Quit",() => { left.project.quit(); },"CmdOrCtrl+Q");
-      left.controller.add("reader","Reader","Stop",() => { left.reader.stop(); },"Esc");
+      left.controller.add('reader', '*', 'About', () => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Left') }, 'CmdOrCtrl+,')
+      left.controller.add('reader', '*', 'Fullscreen', () => { app.toggle_fullscreen() }, 'CmdOrCtrl+Enter')
+      left.controller.add('reader', '*', 'Hide', () => { app.toggle_visible() }, 'CmdOrCtrl+H')
+      left.controller.add('reader', '*', 'Reset', () => { left.theme.reset() }, 'CmdOrCtrl+Backspace')
+      left.controller.add('reader', '*', 'Quit', () => { left.project.quit() }, 'CmdOrCtrl+Q')
+      left.controller.add('reader', 'Reader', 'Stop', () => { left.reader.stop() }, 'Esc')
 
-      left.controller.add("operator","*","About",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Left'); },"CmdOrCtrl+,");
-      left.controller.add("operator","*","Fullscreen",() => { app.toggle_fullscreen(); },"CmdOrCtrl+Enter");
-      left.controller.add("operator","*","Hide",() => { app.toggle_visible(); },"CmdOrCtrl+H");
-      left.controller.add("operator","*","Reset",() => { left.theme.reset(); },"CmdOrCtrl+Backspace");
-      left.controller.add("operator","*","Quit",() => { left.project.quit(); },"CmdOrCtrl+Q");
+      left.controller.add('operator', '*', 'About', () => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Left') }, 'CmdOrCtrl+,')
+      left.controller.add('operator', '*', 'Fullscreen', () => { app.toggle_fullscreen() }, 'CmdOrCtrl+Enter')
+      left.controller.add('operator', '*', 'Hide', () => { app.toggle_visible() }, 'CmdOrCtrl+H')
+      left.controller.add('operator', '*', 'Reset', () => { left.theme.reset() }, 'CmdOrCtrl+Backspace')
+      left.controller.add('operator', '*', 'Quit', () => { left.project.quit() }, 'CmdOrCtrl+Q')
 
-      left.controller.add("insert","*","About",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Left'); },"CmdOrCtrl+,");
-      left.controller.add("insert","*","Fullscreen",() => { app.toggle_fullscreen(); },"CmdOrCtrl+Enter");
-      left.controller.add("insert","*","Hide",() => { app.toggle_visible(); },"CmdOrCtrl+H");
-      left.controller.add("insert","*","Reset",() => { left.theme.reset(); },"CmdOrCtrl+Backspace");
-      left.controller.add("insert","*","Quit",() => { left.project.quit(); },"CmdOrCtrl+Q");
+      left.controller.add('insert', '*', 'About', () => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Left') }, 'CmdOrCtrl+,')
+      left.controller.add('insert', '*', 'Fullscreen', () => { app.toggle_fullscreen() }, 'CmdOrCtrl+Enter')
+      left.controller.add('insert', '*', 'Hide', () => { app.toggle_visible() }, 'CmdOrCtrl+H')
+      left.controller.add('insert', '*', 'Reset', () => { left.theme.reset() }, 'CmdOrCtrl+Backspace')
+      left.controller.add('insert', '*', 'Quit', () => { left.project.quit() }, 'CmdOrCtrl+Q')
 
-      left.controller.add("insert","Insert","Date",() => { left.insert.date(); },"CmdOrCtrl+D");
-      left.controller.add("insert","Insert","Time",() => { left.insert.time(); },"CmdOrCtrl+T");
-      left.controller.add("insert","Insert","Path",() => { left.insert.path(); },"CmdOrCtrl+P");
-      left.controller.add("insert","Insert","Header",() => { left.insert.header(); },"CmdOrCtrl+H");
-      left.controller.add("insert","Insert","SubHeader",() => { left.insert.subheader(); },"CmdOrCtrl+Shift+H");
-      left.controller.add("insert","Insert","Comment",() => { left.insert.comment(); },"CmdOrCtrl+/");
-      left.controller.add("insert","Insert","Line",() => { left.insert.line(); },"CmdOrCtrl+L");
-      left.controller.add("insert","Insert","List",() => { left.insert.list(); },"CmdOrCtrl+-");
-      left.controller.add("insert","Mode","Stop",() => { left.insert.stop(); },"Esc");
+      left.controller.add('insert', 'Insert', 'Date', () => { left.insert.date() }, 'CmdOrCtrl+D')
+      left.controller.add('insert', 'Insert', 'Time', () => { left.insert.time() }, 'CmdOrCtrl+T')
+      left.controller.add('insert', 'Insert', 'Path', () => { left.insert.path() }, 'CmdOrCtrl+P')
+      left.controller.add('insert', 'Insert', 'Header', () => { left.insert.header() }, 'CmdOrCtrl+H')
+      left.controller.add('insert', 'Insert', 'SubHeader', () => { left.insert.subheader() }, 'CmdOrCtrl+Shift+H')
+      left.controller.add('insert', 'Insert', 'Comment', () => { left.insert.comment() }, 'CmdOrCtrl+/')
+      left.controller.add('insert', 'Insert', 'Line', () => { left.insert.line() }, 'CmdOrCtrl+L')
+      left.controller.add('insert', 'Insert', 'List', () => { left.insert.list() }, 'CmdOrCtrl+-')
+      left.controller.add('insert', 'Mode', 'Stop', () => { left.insert.stop() }, 'Esc')
 
-      left.controller.add_role("operator","Edit","undo");
-      left.controller.add_role("operator","Edit","redo");
-      left.controller.add_role("operator","Edit","cut");
-      left.controller.add_role("operator","Edit","copy");
-      left.controller.add_role("operator","Edit","paste");
-      left.controller.add_role("operator","Edit","delete");
-      left.controller.add_role("operator","Edit","selectall");
+      left.controller.add_role('operator', 'Edit', 'undo')
+      left.controller.add_role('operator', 'Edit', 'redo')
+      left.controller.add_role('operator', 'Edit', 'cut')
+      left.controller.add_role('operator', 'Edit', 'copy')
+      left.controller.add_role('operator', 'Edit', 'paste')
+      left.controller.add_role('operator', 'Edit', 'delete')
+      left.controller.add_role('operator', 'Edit', 'selectall')
 
-      left.controller.add("operator","Find","Find",() => { left.operator.start("find: "); },"CmdOrCtrl+F");
-      left.controller.add("operator","Find","Find Next",() => { left.operator.find_next(); },"CmdOrCtrl+N");
-      left.controller.add("operator","Operator","Stop",() => { left.operator.stop(); },"Esc");
+      left.controller.add('operator', 'Find', 'Find', () => { left.operator.start('find: ') }, 'CmdOrCtrl+F')
+      left.controller.add('operator', 'Find', 'Find Next', () => { left.operator.find_next() }, 'CmdOrCtrl+N')
+      left.controller.add('operator', 'Operator', 'Stop', () => { left.operator.stop() }, 'Esc')
 
-      left.controller.commit();
-
+      left.controller.commit()
     </script>
   </body>
 </html>

--- a/desktop/sources/left.js
+++ b/desktop/sources/left.js
@@ -1,5 +1,3 @@
-/* global left */
-
 'use strict'
 
 const Theme = require('./scripts/lib/theme')

--- a/desktop/sources/left.js
+++ b/desktop/sources/left.js
@@ -2,6 +2,19 @@
 
 'use strict'
 
+const Theme = require('./scripts/lib/theme')
+const Controller = require('./scripts/lib/controller')
+const Dictionary = require('./scripts/dictionary')
+const Operator = require('./scripts/operator')
+const Navi = require('./scripts/navi')
+const Stats = require('./scripts/stats')
+const Go = require('./scripts/go')
+const Project = require('./scripts/project')
+const Reader = require('./scripts/reader')
+const Insert = require('./scripts/insert')
+
+const EOL = '\n'
+
 function Left () {
   this.theme = new Theme()
   this.controller = new Controller()
@@ -310,4 +323,4 @@ function Left () {
   }
 }
 
-let EOL = '\n'
+module.exports = Left

--- a/desktop/sources/scripts/dictionary.js
+++ b/desktop/sources/scripts/dictionary.js
@@ -1,6 +1,8 @@
-/* global left, SYN_DB */
+/* global left */
 
 'use strict'
+
+const SYN_DB = require('./synonyms')
 
 function Dictionary () {
   this.vocabulary = []

--- a/desktop/sources/scripts/dictionary.js
+++ b/desktop/sources/scripts/dictionary.js
@@ -1,5 +1,3 @@
-/* global left */
-
 'use strict'
 
 const SYN_DB = require('./synonyms')

--- a/desktop/sources/scripts/dictionary.js
+++ b/desktop/sources/scripts/dictionary.js
@@ -1,3 +1,5 @@
+/* global left, SYN_DB */
+
 'use strict'
 
 function Dictionary () {
@@ -24,15 +26,15 @@ function Dictionary () {
   this.build_synonyms = function () {
     const time = performance.now()
 
-    for (const target_word in SYN_DB) {
-      const synonyms = SYN_DB[target_word]
-      this.add_word(target_word)
-      for (const word_id in synonyms) {
-        const target_parent = synonyms[word_id]
-        if (this.synonyms[target_parent] && this.synonyms[target_parent].constructor == Array) {
-          this.synonyms[target_parent][this.synonyms[target_parent].length] = target_word
+    for (const targetWord in SYN_DB) {
+      const synonyms = SYN_DB[targetWord]
+      this.add_word(targetWord)
+      for (const wordID in synonyms) {
+        const targetParent = synonyms[wordID]
+        if (this.synonyms[targetParent] && this.synonyms[targetParent].constructor === Array) {
+          this.synonyms[targetParent][this.synonyms[targetParent].length] = targetWord
         } else {
-          this.synonyms[target_parent] = [target_word]
+          this.synonyms[targetParent] = [targetWord]
         }
       }
     }
@@ -43,7 +45,7 @@ function Dictionary () {
     const target = str.toLowerCase()
 
     for (const id in this.vocabulary) {
-      if (this.vocabulary[id].substr(0, target.length) != target) { continue }
+      if (this.vocabulary[id].substr(0, target.length) !== target) { continue }
       return this.vocabulary[id]
     }
     return null
@@ -58,7 +60,7 @@ function Dictionary () {
       return uniq(this.synonyms[target])
     }
 
-    if (target[target.length - 1] == 's') {
+    if (target[target.length - 1] === 's') {
       const singular = this.synonyms[target.substr(0, target.length - 1)]
       if (this.synonyms[singular]) {
         return uniq(this.synonyms[singular])
@@ -70,13 +72,15 @@ function Dictionary () {
 
   this.update = function () {
     const time = performance.now()
-    const words = left.textarea_el.value.toLowerCase().split(/[^\w\-]+/)
+    const words = left.textarea_el.value.toLowerCase().split(/[^\w-]+/)
 
-    for (const word_id in words) {
-      this.add_word(words[word_id])
+    for (const wordID in words) {
+      this.add_word(words[wordID])
     }
     console.log(`Updated Dictionary in ${(performance.now() - time).toFixed(2)}ms.`)
   }
 
-  function uniq (a1) { const a2 = []; for (const id in a1) { if (a2.indexOf(a1[id]) == -1) { a2[a2.length] = a1[id] } } return a2 }
+  function uniq (a1) { const a2 = []; for (const id in a1) { if (a2.indexOf(a1[id]) === -1) { a2[a2.length] = a1[id] } } return a2 }
 }
+
+module.exports = Dictionary

--- a/desktop/sources/scripts/events.js
+++ b/desktop/sources/scripts/events.js
@@ -1,5 +1,3 @@
-/* global left */
-
 'use strict'
 
 document.onkeydown = function keyDown (e) {

--- a/desktop/sources/scripts/events.js
+++ b/desktop/sources/scripts/events.js
@@ -1,10 +1,12 @@
+/* global left */
+
 'use strict'
 
-document.onkeydown = function key_down (e) {
+document.onkeydown = function keyDown (e) {
   left.last_char = e.key
 
   // Faster than Electron
-  if (e.keyCode == 9) {
+  if (e.keyCode === 9) {
     if (e.shiftKey) {
       left.select_synonym()
     } else {
@@ -15,12 +17,12 @@ document.onkeydown = function key_down (e) {
   }
   // Faster than Electron
   if (e.metaKey || e.ctrlKey) {
-    if (e.keyCode == 221) {
+    if (e.keyCode === 221) {
       left.navi.next_marker()
       e.preventDefault()
       return
     }
-    if (e.keyCode == 291) {
+    if (e.keyCode === 291) {
       left.navi.prev_marker()
       e.preventDefault()
       return
@@ -28,41 +30,41 @@ document.onkeydown = function key_down (e) {
   }
 
   // Reset index on space
-  if (e.key == ' ' || e.key == 'Enter') {
+  if (e.key === ' ' || e.key === 'Enter') {
     left.selection.index = 0
   }
 
-  if (e.key.substring(0, 5) == 'Arrow') {
+  if (e.key.substring(0, 5) === 'Arrow') {
     setTimeout(() => left.update(), 0) // force the refresh event to happen after the selection updates
     return
   }
 
   // Slower Refresh
-  if (e.key == 'Enter') {
+  if (e.key === 'Enter') {
     setTimeout(() => { left.dictionary.update(); left.update() }, 16)
   }
 }
 
 document.onkeyup = (e) => {
-  if (e.keyCode == 16) { // Shift
+  if (e.keyCode === 16) { // Shift
     left.selection.index = 0
     left.update()
     return
   }
-  if (e.keyCode != 9) {
+  if (e.keyCode !== 9) {
     left.update()
   }
 }
 
 // Selection Change
-let last_selection = null
+let lastSelection = null
 
 window.addEventListener('mousemove', function (e) {
-  if (last_selection && last_selection.start == left.textarea_el.selectionStart && last_selection.end == left.textarea_el.selectionEnd) {
+  if (lastSelection && lastSelection.start === left.textarea_el.selectionStart && lastSelection.end === left.textarea_el.selectionEnd) {
     return
   }
   left.update()
-  last_selection = { start: left.textarea_el.selectionStart, end: left.textarea_el.selectionEnd }
+  lastSelection = { start: left.textarea_el.selectionStart, end: left.textarea_el.selectionEnd }
 })
 
 window.addEventListener('dragover', function (e) {
@@ -81,7 +83,7 @@ window.addEventListener('drop', function (e) {
     const file = files[id]
     if (!file.path) { continue }
     if (file.type && !file.type.match(/text.*/)) { console.log(`Skipped ${file.type} : ${file.path}`); continue }
-    if (file.path && file.path.substr(-3, 3) == 'thm') { continue }
+    if (file.path && file.path.substr(-3, 3) === 'thm') { continue }
 
     left.project.add(file.path)
   }
@@ -90,7 +92,7 @@ window.addEventListener('drop', function (e) {
   left.navi.next_page()
 })
 
-document.onclick = function on_click (e) {
+document.onclick = function onClick (e) {
   left.selection.index = 0
   left.operator.stop()
   left.reader.stop()

--- a/desktop/sources/scripts/go.js
+++ b/desktop/sources/scripts/go.js
@@ -61,7 +61,7 @@ function Go () {
     if (startingWith) { target = target.substr(0, target.length - 1) }
     if (endingWith) { target = target.substr(1, target.length - 1) }
 
-    // TODO: fix length reference here?
+    // TODO: fix length reference here: not sure what it is supposed to be
     if (left.textarea_el.value.substr(from, length).indexOf(target) === -1 || tries < 1) { console.log('failed'); return }
 
     const length = left.textarea_el.value.length - from

--- a/desktop/sources/scripts/go.js
+++ b/desktop/sources/scripts/go.js
@@ -1,3 +1,5 @@
+/* global left, EOL */
+
 'use strict'
 
 function Go () {
@@ -40,7 +42,7 @@ function Go () {
       this.scroll_to(from, to)
     }
 
-    return from == -1 ? null : from
+    return from === -1 ? null : from
   }
 
   this.to_next = function (str, scroll = true) {
@@ -51,34 +53,35 @@ function Go () {
     this.to(next, next, scroll)
   }
 
-  this.to_word = function (word, from = 0, tries = 0, starting_with = false, ending_with = false) {
+  this.to_word = function (word, from = 0, tries = 0, startingWith = false, endingWith = false) {
     let target = word
 
-    if (starting_with) { target = target.substr(0, target.length - 1) }
-    if (ending_with) { target = target.substr(1, target.length - 1) }
+    if (startingWith) { target = target.substr(0, target.length - 1) }
+    if (endingWith) { target = target.substr(1, target.length - 1) }
 
-    if (left.textarea_el.value.substr(from, length).indexOf(target) == -1 || tries < 1) { console.log('failed'); return }
+    // TODO: fix length reference here?
+    if (left.textarea_el.value.substr(from, length).indexOf(target) === -1 || tries < 1) { console.log('failed'); return }
 
     const length = left.textarea_el.value.length - from
     const segment = left.textarea_el.value.substr(from, length)
     const location = segment.indexOf(target)
-    const char_before = segment.substr(location - 1, 1)
-    const char_after = segment.substr(location + target.length, 1)
+    const charBefore = segment.substr(location - 1, 1)
+    const charAfter = segment.substr(location + target.length, 1)
 
     // Check for full word
-    if (!starting_with && !ending_with && !char_before.match(/[a-z]/i) && !char_after.match(/[a-z]/i)) {
+    if (!startingWith && !endingWith && !charBefore.match(/[a-z]/i) && !charAfter.match(/[a-z]/i)) {
       left.select(location + from, location + from + target.length)
       const perc = (left.textarea_el.selectionEnd / parseFloat(left.chars_count))
       const offset = 60
       left.textarea_el.scrollTop = (left.textarea_el.scrollHeight * perc) - offset
       return location
-    } else if (starting_with && !char_before.match(/[a-z]/i) && char_after.match(/[a-z]/i)) {
+    } else if (startingWith && !charBefore.match(/[a-z]/i) && charAfter.match(/[a-z]/i)) {
       left.select(location + from, location + from + target.length)
       const perc = (left.textarea_el.selectionEnd / parseFloat(left.chars_count))
       const offset = 60
       left.textarea_el.scrollTop = (left.textarea_el.scrollHeight * perc) - offset
       return location
-    } else if (ending_with && char_before.match(/[a-z]/i) && !char_after.match(/[a-z]/i)) {
+    } else if (endingWith && charBefore.match(/[a-z]/i) && !charAfter.match(/[a-z]/i)) {
       left.select(location + from, location + from + target.length)
       const perc = (left.textarea_el.selectionEnd / parseFloat(left.chars_count))
       const offset = 60
@@ -86,19 +89,19 @@ function Go () {
       return location
     }
 
-    this.to_word(word, location + target.length, tries - 1, starting_with, ending_with)
+    this.to_word(word, location + target.length, tries - 1, startingWith, endingWith)
   }
 
   this.scroll_to = function (from, to) {
-    const text_val = left.textarea_el.value
+    const textVal = left.textarea_el.value
     const div = document.createElement('div')
-    div.innerHTML = text_val.slice(0, to)
+    div.innerHTML = textVal.slice(0, to)
     document.body.appendChild(div)
-    animate_scroll_to(left.textarea_el, div.offsetHeight - 60, 200)
+    animateScrollTo(left.textarea_el, div.offsetHeight - 60, 200)
     div.remove()
   }
 
-  function animate_scroll_to (element, to, duration) {
+  function animateScrollTo (element, to, duration) {
     const start = element.scrollTop
     const change = to - start
     let currentTime = 0
@@ -130,3 +133,5 @@ function Go () {
 
   function clamp (v, min, max) { return v < min ? min : v > max ? max : v }
 }
+
+module.exports = Go

--- a/desktop/sources/scripts/go.js
+++ b/desktop/sources/scripts/go.js
@@ -1,6 +1,8 @@
-/* global left, EOL */
+/* global left */
 
 'use strict'
+
+const EOL = '\n'
 
 function Go () {
   this.to_page = function (id = 0, line = 0) {

--- a/desktop/sources/scripts/go.js
+++ b/desktop/sources/scripts/go.js
@@ -1,5 +1,3 @@
-/* global left */
-
 'use strict'
 
 const EOL = '\n'

--- a/desktop/sources/scripts/insert.js
+++ b/desktop/sources/scripts/insert.js
@@ -1,6 +1,8 @@
-/* global left, EOL */
+/* global left */
 
 'use strict'
+
+const EOL = '\n'
 
 function Insert () {
   this.is_active = false

--- a/desktop/sources/scripts/insert.js
+++ b/desktop/sources/scripts/insert.js
@@ -1,3 +1,5 @@
+/* global left, EOL */
+
 'use strict'
 
 function Insert () {
@@ -32,18 +34,18 @@ function Insert () {
   }
 
   this.path = function () {
-    if (left.project.paths().length == 0) { this.stop(); return }
+    if (left.project.paths().length === 0) { this.stop(); return }
 
     left.inject(left.project.paths()[left.project.index])
     this.stop()
   }
 
   this.header = function () {
-    const is_multiline = left.selected().match(/[^\r\n]+/g)
+    const isMultiline = left.selected().match(/[^\r\n]+/g)
 
-    if (left.prev_character() == EOL && !is_multiline) {
+    if (left.prev_character() === EOL && !isMultiline) {
       left.inject('# ')
-    } else if (is_multiline) {
+    } else if (isMultiline) {
       left.inject_multiline('# ')
     } else {
       left.inject_line('# ')
@@ -52,11 +54,11 @@ function Insert () {
   }
 
   this.subheader = function () {
-    const is_multiline = left.selected().match(/[^\r\n]+/g)
+    const isMultiline = left.selected().match(/[^\r\n]+/g)
 
-    if (left.prev_character() == EOL && !is_multiline) {
+    if (left.prev_character() === EOL && !isMultiline) {
       left.inject('## ')
-    } else if (is_multiline) {
+    } else if (isMultiline) {
       left.inject_multiline('## ')
     } else {
       left.inject_line('## ')
@@ -65,11 +67,11 @@ function Insert () {
   }
 
   this.comment = function () {
-    const is_multiline = left.selected().match(/[^\r\n]+/g)
+    const isMultiline = left.selected().match(/[^\r\n]+/g)
 
-    if (left.prev_character() == EOL && !is_multiline) {
+    if (left.prev_character() === EOL && !isMultiline) {
       left.inject('-- ')
-    } else if (is_multiline) {
+    } else if (isMultiline) {
       left.inject_multiline('-- ')
     } else {
       left.inject_line('-- ')
@@ -78,11 +80,11 @@ function Insert () {
   }
 
   this.list = function () {
-    const is_multiline = left.selected().match(/[^\r\n]+/g)
+    const isMultiline = left.selected().match(/[^\r\n]+/g)
 
-    if (left.prev_character() == EOL && !is_multiline) {
+    if (left.prev_character() === EOL && !isMultiline) {
       left.inject('- ')
-    } else if (is_multiline) {
+    } else if (isMultiline) {
       left.inject_multiline('- ')
     } else {
       left.inject_line('- ')
@@ -91,7 +93,7 @@ function Insert () {
   }
 
   this.line = function () {
-    if (left.prev_character() != EOL) {
+    if (left.prev_character() !== EOL) {
       left.inject(EOL)
     }
     left.inject('===================== \n')
@@ -102,3 +104,5 @@ function Insert () {
     return `<b>Insert Mode</b> c-D <i>Date</i> c-T <i>Time</i> ${left.project.paths().length > 0 ? 'c-P <i>Path</i> ' : ''}c-H <i>Header</i> c-/ <i>Comment</i> Esc <i>Exit</i>.`
   }
 }
+
+module.exports = Insert

--- a/desktop/sources/scripts/insert.js
+++ b/desktop/sources/scripts/insert.js
@@ -1,5 +1,3 @@
-/* global left */
-
 'use strict'
 
 const EOL = '\n'

--- a/desktop/sources/scripts/left.js
+++ b/desktop/sources/scripts/left.js
@@ -1,3 +1,5 @@
+/* global left */
+
 'use strict'
 
 function Left () {
@@ -66,10 +68,10 @@ function Left () {
   }
 
   this.update = function (hard = false) {
-    let next_char = left.textarea_el.value.substr(left.textarea_el.selectionEnd, 1)
+    let nextChar = left.textarea_el.value.substr(left.textarea_el.selectionEnd, 1)
 
     left.selection.word = this.active_word()
-    left.suggestion = (next_char == '' || next_char == ' ' || next_char == EOL) ? left.dictionary.find_suggestion(left.selection.word) : null
+    left.suggestion = (nextChar === '' || nextChar === ' ' || nextChar === EOL) ? left.dictionary.find_suggestion(left.selection.word) : null
     left.synonyms = left.dictionary.find_synonym(left.selection.word)
     left.selection.url = this.active_url()
 
@@ -81,7 +83,7 @@ function Left () {
   //
 
   this.select_autocomplete = function () {
-    if (left.selection.word.trim() != '' && left.suggestion && left.suggestion.toLowerCase() != left.active_word().toLowerCase()) {
+    if (left.selection.word.trim() !== '' && left.suggestion && left.suggestion.toLowerCase() !== left.active_word().toLowerCase()) {
       left.autocomplete()
     } else {
       left.inject('\u00a0\u00a0')
@@ -197,7 +199,7 @@ function Left () {
     let w = left.textarea_el.value.substr(l.from, l.to - l.from)
 
     // Preserve capitalization
-    if (w.substr(0, 1) == w.substr(0, 1).toUpperCase()) {
+    if (w.substr(0, 1) === w.substr(0, 1).toUpperCase()) {
       word = word.substr(0, 1).toUpperCase() + word.substr(1, word.length)
     }
 
@@ -213,8 +215,8 @@ function Left () {
     this.update()
   }
 
-  this.replace_line = function (id, new_text, del = false) // optional arg for deleting the line, used in actions
-  {
+  // del is an optional arg for deleting the line, used in actions
+  this.replace_line = function (id, newText, del = false) {
     let lineArr = this.textarea_el.value.split(EOL, parseInt(id) + 1)
     let arrJoin = lineArr.join(EOL)
 
@@ -222,33 +224,33 @@ function Left () {
     let to = arrJoin.length
 
     // splicing the string
-    let new_text_value = this.textarea_el.value.slice(0, del ? from - 1 : from) + new_text + this.textarea_el.value.slice(to)
+    let newTextValue = this.textarea_el.value.slice(0, del ? from - 1 : from) + newText + this.textarea_el.value.slice(to)
 
     // the cursor automatically moves to the changed position, so we have to set it back
-    let cursor_start = this.textarea_el.selectionStart
-    let cursor_end = this.textarea_el.selectionEnd
-    let old_length = this.textarea_el.value.length
-    let old_scroll = this.textarea_el.scrollTop
+    let cursorStart = this.textarea_el.selectionStart
+    let cursorEnd = this.textarea_el.selectionEnd
+    let oldLength = this.textarea_el.value.length
+    let oldScroll = this.textarea_el.scrollTop
     // setting text area
-    this.load(new_text_value)
+    this.load(newTextValue)
     // adjusting the cursor position for the change in length
-    let length_dif = this.textarea_el.value.length - old_length
-    if (cursor_start > to) {
-      cursor_start += length_dif
-      cursor_end += length_dif
+    let lengthDif = this.textarea_el.value.length - oldLength
+    if (cursorStart > to) {
+      cursorStart += lengthDif
+      cursorEnd += lengthDif
     }
     // setting the cursor position
     if (this.textarea_el.setSelectionRange) {
-      this.textarea_el.setSelectionRange(cursor_start, cursor_end)
+      this.textarea_el.setSelectionRange(cursorStart, cursorEnd)
     } else if (this.textarea_el.createTextRange) {
       let range = this.textarea_el.createTextRange()
       range.collapse(true)
-      range.moveEnd('character', cursor_end)
-      range.moveStart('character', cursor_start)
+      range.moveEnd('character', cursorEnd)
+      range.moveStart('character', cursorStart)
       range.select()
     }
     // setting the scroll position
-    this.textarea_el.scrollTop = old_scroll
+    this.textarea_el.scrollTop = oldScroll
     // this function turned out a lot longer than I was expecting. Ah well :/
   }
 

--- a/desktop/sources/scripts/lib/controller.js
+++ b/desktop/sources/scripts/lib/controller.js
@@ -1,3 +1,5 @@
+/* global EOL, fs, app, dialog */
+
 'use strict'
 
 function Controller () {
@@ -56,24 +58,24 @@ function Controller () {
     let fileName = dialog.showSaveDialog(app.win)
 
     if (fileName === undefined) { return }
-    fileName = fileName.substr(-4, 4) != '.svg' ? fileName + '.svg' : fileName
+    fileName = fileName.substr(-4, 4) !== '.svg' ? fileName + '.svg' : fileName
     fs.writeFile(fileName, svg)
     fs.writeFile(fileName.replace('.svg', '.md'), txt)
   }
 
   this.generate_svg = function (m) {
-    let svg_html = ''
+    let svgHTML = ''
 
     for (const id in this.layout) {
       let key = this.layout[id]
       let acc = this.accelerator_for_key(key.name, m)
-      svg_html += `<rect x="${key.x + 1}" y="${key.y + 1}" width="${key.width - 2}" height="${key.height - 2}" rx="4" ry="4" title="${key.name}" stroke="#ccc" fill="none" stroke-width="1"/>`
-      svg_html += `<rect x="${key.x + 3}" y="${key.y + 3}" width="${key.width - 6}" height="${key.height - 12}" rx="3" ry="3" title="${key.name}" stroke="${acc.basic ? '#000' : acc.ctrl ? '#ccc' : '#fff'}" fill="${acc.basic ? '#000' : acc.ctrl ? '#ccc' : '#fff'}" stroke-width="1"/>`
-      svg_html += `<text x="${key.x + 10}" y="${key.y + 20}" font-size='11' font-family='Input Mono' stroke-width='0' fill='${acc.basic ? '#fff' : '#000'}'>${key.name.toUpperCase()}</text>`
-      svg_html += acc && acc.basic ? `<text x="${key.x + 10}" y="${key.y + 35}" font-size='7' font-family='Input Mono' stroke-width='0' fill='#fff'>${acc.basic}</text>` : ''
-      svg_html += acc && acc.ctrl ? `<text x="${key.x + 10}" y="${key.y + 45}" font-size='7' font-family='Input Mono' stroke-width='0' fill='#000'>${acc.ctrl}</text>` : ''
+      svgHTML += `<rect x="${key.x + 1}" y="${key.y + 1}" width="${key.width - 2}" height="${key.height - 2}" rx="4" ry="4" title="${key.name}" stroke="#ccc" fill="none" stroke-width="1"/>`
+      svgHTML += `<rect x="${key.x + 3}" y="${key.y + 3}" width="${key.width - 6}" height="${key.height - 12}" rx="3" ry="3" title="${key.name}" stroke="${acc.basic ? '#000' : acc.ctrl ? '#ccc' : '#fff'}" fill="${acc.basic ? '#000' : acc.ctrl ? '#ccc' : '#fff'}" stroke-width="1"/>`
+      svgHTML += `<text x="${key.x + 10}" y="${key.y + 20}" font-size='11' font-family='Input Mono' stroke-width='0' fill='${acc.basic ? '#fff' : '#000'}'>${key.name.toUpperCase()}</text>`
+      svgHTML += acc && acc.basic ? `<text x="${key.x + 10}" y="${key.y + 35}" font-size='7' font-family='Input Mono' stroke-width='0' fill='#fff'>${acc.basic}</text>` : ''
+      svgHTML += acc && acc.ctrl ? `<text x="${key.x + 10}" y="${key.y + 45}" font-size='7' font-family='Input Mono' stroke-width='0' fill='#000'>${acc.ctrl}</text>` : ''
     }
-    return `<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" width="900" height="300" version="1.0" style="fill:none;stroke:black;stroke-width:2px;">${svg_html}</svg>`
+    return `<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" width="900" height="300" version="1.0" style="fill:none;stroke:black;stroke-width:2px;">${svgHTML}</svg>`
   }
 
   this.documentation = function () {
@@ -82,7 +84,7 @@ function Controller () {
     txt += this.documentation_for_mode('default', this.menu.default)
 
     for (let name in this.menu) {
-      if (name == 'default') { continue }
+      if (name === 'default') { continue }
       txt += this.documentation_for_mode(name, this.menu[name])
     }
     return txt
@@ -92,7 +94,7 @@ function Controller () {
     let txt = `## ${name} Mode\n\n`
 
     for (const id in mode) {
-      if (id == '*' || id == 'Edit') { continue }
+      if (id === '*' || id === 'Edit') { continue }
       txt += `### ${id}\n`
       for (let name in mode[id]) {
         let option = mode[id][name]
@@ -110,8 +112,8 @@ function Controller () {
       let options = menu[cat]
       for (const id in options.submenu) {
         let option = options.submenu[id]; if (option.role) { continue }
-        acc.basic = (option.accelerator.toLowerCase() == key.toLowerCase()) ? option.label.toUpperCase().replace('TOGGLE ', '').substr(0, 8).trim() : acc.basic
-        acc.ctrl = (option.accelerator.toLowerCase() == ('CmdOrCtrl+' + key).toLowerCase()) ? option.label.toUpperCase().replace('TOGGLE ', '').substr(0, 8).trim() : acc.ctrl
+        acc.basic = (option.accelerator.toLowerCase() === key.toLowerCase()) ? option.label.toUpperCase().replace('TOGGLE ', '').substr(0, 8).trim() : acc.basic
+        acc.ctrl = (option.accelerator.toLowerCase() === ('CmdOrCtrl+' + key).toLowerCase()) ? option.label.toUpperCase().replace('TOGGLE ', '').substr(0, 8).trim() : acc.ctrl
       }
     }
     return acc

--- a/desktop/sources/scripts/lib/controller.js
+++ b/desktop/sources/scripts/lib/controller.js
@@ -1,6 +1,10 @@
-/* global EOL, fs, app, dialog */
-
 'use strict'
+
+const fs = require('fs')
+const { remote } = require('electron')
+const { app, dialog } = remote
+
+const EOL = '\n'
 
 function Controller () {
   this.menu = { default: {} }
@@ -184,4 +188,4 @@ function Controller () {
   ]
 }
 
-module.exports = new Controller()
+module.exports = Controller

--- a/desktop/sources/scripts/lib/theme.js
+++ b/desktop/sources/scripts/lib/theme.js
@@ -6,9 +6,6 @@ function Theme (default_theme = { background: '#222', f_high: '#fff', f_med: '#c
   this.el = document.createElement('style')
   this.el.type = 'text/css'
 
-  this.callback
-  this.active
-
   this.collection = {
     default: default_theme,
     noir: { background: '#222', f_high: '#fff', f_med: '#ccc', f_low: '#999', f_inv: '#fff', b_high: '#888', b_med: '#666', b_low: '#444', b_inv: '#000' },
@@ -23,7 +20,7 @@ function Theme (default_theme = { background: '#222', f_high: '#fff', f_med: '#c
 
   this.start = function () {
     console.log('Theme', 'Starting..')
-    let storage = is_json(localStorage.theme) ? JSON.parse(localStorage.theme) : this.collection.default
+    let storage = isJSON(localStorage.theme) ? JSON.parse(localStorage.theme) : this.collection.default
     this.load(!storage.background ? this.collection.default : storage)
   }
 
@@ -60,9 +57,7 @@ function Theme (default_theme = { background: '#222', f_high: '#fff', f_med: '#c
   }
 
   this.parse = function (any) {
-    let theme
-
-    if (any && any.background) { return any } else if (any && any.data) { return any.data } else if (any && is_json(any)) { return JSON.parse(any) } else if (any && is_html(any)) { return this.extract(any) }
+    if (any && any.background) { return any } else if (any && any.data) { return any.data } else if (any && isJSON(any)) { return JSON.parse(any) } else if (any && isHTML(any)) { return this.extract(any) }
 
     return null
   }
@@ -102,7 +97,7 @@ function Theme (default_theme = { background: '#222', f_high: '#fff', f_med: '#c
   }
 
   this.invert = function () {
-    this.load(this.active.background == this.collection.noir.background ? this.collection.pale : this.collection.noir)
+    this.load(this.active.background === this.collection.noir.background ? this.collection.pale : this.collection.noir)
   }
 
   // Drag
@@ -132,6 +127,8 @@ function Theme (default_theme = { background: '#222', f_high: '#fff', f_med: '#c
   window.addEventListener('dragover', this.drag)
   window.addEventListener('drop', this.drop)
 
-  function is_json (text) { try { JSON.parse(text); return true } catch (error) { return false } }
-  function is_html (text) { try { new DOMParser().parseFromString(text, 'text/xml'); return true } catch (error) { return false } }
+  function isJSON (text) { try { JSON.parse(text); return true } catch (error) { return false } }
+  function isHTML (text) { try { new DOMParser().parseFromString(text, 'text/xml'); return true } catch (error) { return false } }
 }
+
+module.exports = Theme

--- a/desktop/sources/scripts/navi.js
+++ b/desktop/sources/scripts/navi.js
@@ -1,3 +1,5 @@
+/* global left */
+
 'use strict'
 
 function Navi () {
@@ -25,11 +27,11 @@ function Navi () {
   }
 
   this._page = function (id, page) {
-    return `<li class='page ${left.project.index == id ? 'active' : ''} ${left.project.pages[id].has_changes() ? 'changes' : ''}' onclick='left.go.to_page(${id})'>${page.name()}</li>`
+    return `<li class='page ${left.project.index === id ? 'active' : ''} ${left.project.pages[id].has_changes() ? 'changes' : ''}' onclick='left.go.to_page(${id})'>${page.name()}</li>`
   }
 
   this._marker = function (pid, current, marker, markers) {
-    return `<li class='marker ${marker.type} ${current && current.line == marker.line ? 'active' : ''}' onclick='left.go.to_page(${pid}, ${marker.line})'><span>${marker.text}</span></li>`
+    return `<li class='marker ${marker.type} ${current && current.line === marker.line ? 'active' : ''}' onclick='left.go.to_page(${pid}, ${marker.line})'><span>${marker.text}</span></li>`
   }
 
   this.next_page = function () {
@@ -49,9 +51,9 @@ function Navi () {
     if (!marker) { return }
 
     let markers = left.project.page().markers()
-    let next_index = clamp(marker.id + 1, 0, markers.length - 1)
+    let nextIndex = clamp(marker.id + 1, 0, markers.length - 1)
 
-    left.go.to_page(page, markers[next_index].line)
+    left.go.to_page(page, markers[nextIndex].line)
   }
 
   this.prev_marker = function () {
@@ -61,9 +63,9 @@ function Navi () {
     if (!marker) { return }
 
     let markers = left.project.page().markers()
-    let next_index = clamp(marker.id - 1, 0, markers.length - 1)
+    let nextIndex = clamp(marker.id - 1, 0, markers.length - 1)
 
-    left.go.to_page(page, markers[next_index].line)
+    left.go.to_page(page, markers[nextIndex].line)
   }
 
   this.marker = function () {
@@ -74,7 +76,6 @@ function Navi () {
 
     if (markers.length < 1) { return }
 
-    let prev = null
     for (const id in markers) {
       let marker = markers[id]
       if (marker.line > pos) { return markers[parseInt(id) - 1] }
@@ -83,12 +84,12 @@ function Navi () {
   }
 
   this.on_scroll = function () {
-    let scroll_distance = left.textarea_el.scrollTop
-    let scroll_max = left.textarea_el.scrollHeight - left.textarea_el.offsetHeight
-    let scroll_perc = Math.min(1, (scroll_max == 0) ? 0 : (scroll_distance / scroll_max))
-    let navi_overflow_perc = Math.max(0, (left.navi.el.scrollHeight / window.innerHeight) - 1)
+    let scrollDistance = left.textarea_el.scrollTop
+    let scrollMax = left.textarea_el.scrollHeight - left.textarea_el.offsetHeight
+    let scrollPerc = Math.min(1, (scrollMax === 0) ? 0 : (scrollDistance / scrollMax))
+    let naviOverflowPerc = Math.max(0, (left.navi.el.scrollHeight / window.innerHeight) - 1)
 
-    left.navi.el.style.transform = 'translateY(' + (-100 * scroll_perc * navi_overflow_perc) + '%)'
+    left.navi.el.style.transform = 'translateY(' + (-100 * scrollPerc * naviOverflowPerc) + '%)'
   }
 
   this.toggle = function () {
@@ -97,3 +98,5 @@ function Navi () {
 
   function clamp (v, min, max) { return v < min ? min : v > max ? max : v }
 }
+
+module.exports = Navi

--- a/desktop/sources/scripts/navi.js
+++ b/desktop/sources/scripts/navi.js
@@ -1,5 +1,3 @@
-/* global left */
-
 'use strict'
 
 function Navi () {

--- a/desktop/sources/scripts/operator.js
+++ b/desktop/sources/scripts/operator.js
@@ -1,6 +1,8 @@
-/* global left, EOL */
+/* global left */
 
 'use strict'
+
+const EOL = '\n'
 
 function Operator () {
   this.el = document.createElement('input'); this.el.id = 'operator'

--- a/desktop/sources/scripts/operator.js
+++ b/desktop/sources/scripts/operator.js
@@ -1,5 +1,3 @@
-/* global left */
-
 'use strict'
 
 const EOL = '\n'

--- a/desktop/sources/scripts/operator.js
+++ b/desktop/sources/scripts/operator.js
@@ -1,3 +1,5 @@
+/* global left, EOL */
+
 'use strict'
 
 function Operator () {
@@ -51,13 +53,13 @@ function Operator () {
   this.on_change = function (e, down = false) {
     if (!this.is_active) { return }
 
-    if (e.key == 'ArrowUp' && down) {
+    if (e.key === 'ArrowUp' && down) {
       this.el.value = this.prev
       e.preventDefault()
       return
     }
 
-    if (!down && (e.key == 'Enter' || e.code == 'Enter')) {
+    if (!down && (e.key === 'Enter' || e.code === 'Enter')) {
       this.active()
       e.preventDefault()
     } else if (!down) {
@@ -154,9 +156,9 @@ function Operator () {
   this.goto = function (q, bang = false) {
     let target = parseInt(q, 10)
 
-    let lines_count = left.textarea_el.value.split(EOL).length - 1
+    let linesCount = left.textarea_el.value.split(EOL).length - 1
 
-    if (q == '' || target < 1 || target > lines_count || Number.isNaN(target)) {
+    if (q === '' || target < 1 || target > linesCount || Number.isNaN(target)) {
       return
     }
 
@@ -166,3 +168,5 @@ function Operator () {
     }
   }
 }
+
+module.exports = Operator

--- a/desktop/sources/scripts/page.js
+++ b/desktop/sources/scripts/page.js
@@ -1,3 +1,5 @@
+/* global left, EOL, fs */
+
 'use strict'
 
 function Page (text = '', path = null) {
@@ -16,7 +18,7 @@ function Page (text = '', path = null) {
       if (this.text && this.text.length > 0) { return true }
       return false
     }
-    return this.load() != this.text
+    return this.load() !== this.text
   }
 
   this.commit = function (text = left.textarea_el.value) {
@@ -48,8 +50,10 @@ function Page (text = '', path = null) {
     let lines = this.text.split(EOL)
     for (const id in lines) {
       let line = lines[id].trim()
-      if (line.substr(0, 2) == '##') { a.push({ id: a.length, text: line.replace('##', '').trim(), line: parseInt(id), type: 'subheader' }) } else if (line.substr(0, 1) == '#') { a.push({ id: a.length, text: line.replace('#', '').trim(), line: parseInt(id), type: 'header' }) } else if (line.substr(0, 2) == '--') { a.push({ id: a.length, text: line.replace('--', '').trim(), line: parseInt(id), type: 'comment' }) }
+      if (line.substr(0, 2) === '##') { a.push({ id: a.length, text: line.replace('##', '').trim(), line: parseInt(id), type: 'subheader' }) } else if (line.substr(0, 1) === '#') { a.push({ id: a.length, text: line.replace('#', '').trim(), line: parseInt(id), type: 'header' }) } else if (line.substr(0, 2) === '--') { a.push({ id: a.length, text: line.replace('--', '').trim(), line: parseInt(id), type: 'comment' }) }
     }
     return a
   }
 }
+
+module.exports = Page

--- a/desktop/sources/scripts/page.js
+++ b/desktop/sources/scripts/page.js
@@ -1,6 +1,9 @@
-/* global left, EOL, fs */
+/* global left */
 
 'use strict'
+
+const fs = require('fs')
+const EOL = '\n'
 
 function Page (text = '', path = null) {
   this.text = text.replace(/\r?\n/g, '\n')

--- a/desktop/sources/scripts/page.js
+++ b/desktop/sources/scripts/page.js
@@ -1,5 +1,3 @@
-/* global left */
-
 'use strict'
 
 const fs = require('fs')

--- a/desktop/sources/scripts/project.js
+++ b/desktop/sources/scripts/project.js
@@ -1,6 +1,15 @@
-/* global left, Splash, Page, fs, app, dialog */
+/* global left */
 
 'use strict'
+
+const fs = require('fs')
+const { remote } = require('electron')
+const { app, dialog } = remote
+
+console.log(app)
+
+const Page = require('./page')
+const Splash = require('./splash')
 
 function Project () {
   this.pages = []

--- a/desktop/sources/scripts/project.js
+++ b/desktop/sources/scripts/project.js
@@ -1,5 +1,3 @@
-/* global left */
-
 'use strict'
 
 const fs = require('fs')

--- a/desktop/sources/scripts/project.js
+++ b/desktop/sources/scripts/project.js
@@ -1,3 +1,5 @@
+/* global left, Splash, Page, fs, app, dialog */
+
 'use strict'
 
 function Project () {
@@ -9,7 +11,7 @@ function Project () {
   this.start = function () {
     // Load previous files
     if (localStorage.hasOwnProperty('paths')) {
-      if (is_json(localStorage.getItem('paths'))) {
+      if (isJSON(localStorage.getItem('paths'))) {
         let paths = JSON.parse(localStorage.getItem('paths'))
         for (const id in paths) {
           left.project.add(paths[id])
@@ -18,7 +20,7 @@ function Project () {
     }
 
     // Add splash
-    if (this.pages.length == 0) {
+    if (this.pages.length === 0) {
       left.project.pages.push(new Splash())
       left.go.to_page(0)
     }
@@ -117,7 +119,7 @@ function Project () {
       if (err) { alert('An error ocurred creating the file ' + err.message); return }
       if (!page.path) {
         page.path = path
-      } else if (page.path != path) {
+      } else if (page.path !== path) {
         left.project.pages.push(new Page(page.text, path))
       }
       left.update()
@@ -126,7 +128,7 @@ function Project () {
   }
 
   this.close = function () {
-    if (this.pages.length == 1) { console.warn('Cannot close'); return }
+    if (this.pages.length === 1) { console.warn('Cannot close'); return }
 
     if (this.page().has_changes()) {
       let response = dialog.showMessageBox(app.win, {
@@ -145,7 +147,7 @@ function Project () {
   }
 
   this.force_close = function () {
-    if (this.pages.length == 1) { console.warn('Cannot close'); return }
+    if (this.pages.length === 1) { console.warn('Cannot close'); return }
 
     console.log('Closing..')
 
@@ -197,7 +199,7 @@ function Project () {
   this.remove_splash = function () {
     for (const id in this.pages) {
       let page = this.pages[id]
-      if (page.text == new Splash().text) {
+      if (page.text === new Splash().text) {
         this.pages.splice(0, 1)
         return
       }
@@ -213,6 +215,7 @@ function Project () {
     return a
   }
 
-  function is_json (text) { try { JSON.parse(text); return true } catch (error) { return false } }
-  function clamp (v, min, max) { return v < min ? min : v > max ? max : v }
+  function isJSON (text) { try { JSON.parse(text); return true } catch (error) { return false } }
 }
+
+module.exports = Project

--- a/desktop/sources/scripts/reader.js
+++ b/desktop/sources/scripts/reader.js
@@ -1,3 +1,5 @@
+/* global left */
+
 'use strict'
 
 function Reader () {
@@ -33,7 +35,7 @@ function Reader () {
   }
 
   this.run = function () {
-    if (left.reader.queue.length == 0) { left.reader.stop(); return }
+    if (left.reader.queue.length === 0) { left.reader.stop(); return }
 
     let words = left.reader.segment.text.split(' ')
     let word = left.reader.queue[0]
@@ -81,16 +83,18 @@ function Reader () {
       longest = words[i]
     }
 
-    let longest_orp = left.reader.find_orp(longest)
-    let longest_pad = longest_orp.index
+    let longestOrp = left.reader.find_orp(longest)
+    let longestPad = longestOrp.index
 
     let pad = ''
 
     let i = 0
-    while (i < longest_pad - (orp.index)) {
+    while (i < longestPad - (orp.index)) {
       pad += '-'
       i += 1
     }
     return pad
   }
 }
+
+module.exports = Reader

--- a/desktop/sources/scripts/reader.js
+++ b/desktop/sources/scripts/reader.js
@@ -1,5 +1,3 @@
-/* global left */
-
 'use strict'
 
 function Reader () {

--- a/desktop/sources/scripts/splash.js
+++ b/desktop/sources/scripts/splash.js
@@ -1,6 +1,6 @@
-/* global Page */
-
 'use strict'
+
+const Page = require('./page')
 
 function Splash () {
   Page.call(this, `# Welcome

--- a/desktop/sources/scripts/splash.js
+++ b/desktop/sources/scripts/splash.js
@@ -1,3 +1,5 @@
+/* global Page */
+
 'use strict'
 
 function Splash () {
@@ -5,7 +7,7 @@ function Splash () {
 
 ## Guide
 
-Left is a simple, minimalist, open-source and cross-platform text editor. 
+Left is a simple, minimalist, open-source and cross-platform text editor.
 
 - Create markers by beginning lines with #, ## or --.
 - Navigate quickly between markers with <c-]> and <c-[>.
@@ -51,3 +53,5 @@ Download additional themes: http://hundredrabbits.itch.io/Left
     return false
   }
 }
+
+module.exports = Splash

--- a/desktop/sources/scripts/stats.js
+++ b/desktop/sources/scripts/stats.js
@@ -1,6 +1,8 @@
-/* global left, EOL */
+/* global left */
 
 'use strict'
+
+const EOL = '\n'
 
 function Stats () {
   this.el = document.createElement('stats')

--- a/desktop/sources/scripts/stats.js
+++ b/desktop/sources/scripts/stats.js
@@ -1,3 +1,5 @@
+/* global left, EOL */
+
 'use strict'
 
 function Stats () {
@@ -13,7 +15,7 @@ function Stats () {
       return
     }
 
-    if (left.textarea_el.selectionStart != left.textarea_el.selectionEnd) {
+    if (left.textarea_el.selectionStart !== left.textarea_el.selectionEnd) {
       this.el.innerHTML = this._selection()
     } else if (left.synonyms) {
       this.el.innerHTML = this._synonyms()
@@ -33,12 +35,13 @@ function Stats () {
   }
 
   this._synonyms = function () {
-    let underlinedSyn = left.synonyms[left.selection.index]
+    // TODO: improve synonyms (#91)
+    // let underlinedSyn = left.synonyms[left.selection.index]
     let html = `<b>${left.selection.word}</b> `
 
     for (const id in left.synonyms) {
       let w = left.synonyms[id]
-      html += parseInt(id) == left.selection.index ? `<i>${w}</i> ` : `${w} `
+      html += parseInt(id) === left.selection.index ? `<i>${w}</i> ` : `${w} `
     }
     return html.trim()
   }
@@ -57,9 +60,9 @@ function Stats () {
   }
 
   this.on_scroll = function () {
-    let scroll_distance = left.textarea_el.scrollTop
-    let scroll_max = left.textarea_el.scrollHeight - left.textarea_el.offsetHeight
-    let ratio = Math.min(1, (scroll_max == 0) ? 0 : (scroll_distance / scroll_max))
+    let scrollDistance = left.textarea_el.scrollTop
+    let scrollMax = left.textarea_el.scrollHeight - left.textarea_el.offsetHeight
+    let ratio = Math.min(1, (scrollMax === 0) ? 0 : (scrollDistance / scrollMax))
     let progress = ['|', '|', '|', '|', '|', '|', '|', '|', '|', '|'].map((v, i) => { return i < ratio * 10 ? '<b>|</b>' : v }).join('')
 
     this.el.innerHTML = `${progress} ${(ratio * 100).toFixed(2)}%`
@@ -85,3 +88,5 @@ function Stats () {
 
   function clamp (v, min, max) { return v < min ? min : v > max ? max : v }
 }
+
+module.exports = Stats

--- a/desktop/sources/scripts/stats.js
+++ b/desktop/sources/scripts/stats.js
@@ -1,5 +1,3 @@
-/* global left */
-
 'use strict'
 
 const EOL = '\n'

--- a/desktop/sources/scripts/synonyms.js
+++ b/desktop/sources/scripts/synonyms.js
@@ -48638,3 +48638,5 @@ const SYN_DB = {
     'orbit'
   ]
 }
+
+module.exports = SYN_DB


### PR DESCRIPTION
- Add `eslint-plugin-html` devDep
- Linted index.html <script>
- Linted all `.js` files, mostly camelCase variable names, X is not defined, X is declared but never used, === instead of ==, etc...
- Changed developer tools keybind to Cmd+Alt+I
- Added menu items to reload and force reload (standard with most Electron apps)

✨ Lint errors is now 1 (a variable is throwing an error but I'm not sure what it's supposed to be. I left a `// TODO` comment at it in `go.js`)

This pull request also changes the way modules are loaded, favoring the more traditional Node.js `require()` over HTML `<script>` tags. This reduces the number of global variables to keep track of, and improves code clarity.

As always, let me know if you disagree with any changes or want things changed!