### PR TITLE
Synonym improvements

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@types/node": {
-      "version": "8.10.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.29.tgz",
-      "integrity": "sha512-zbteaWZ2mdduacm0byELwtRyhYE40aK+pAanQk415gr1eRuu67x7QGOLmn8jz5zI8LDK7d0WI/oT6r5Trz4rzQ==",
+      "version": "8.10.36",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.36.tgz",
+      "integrity": "sha512-SL6KhfM7PTqiFmbCW3eVNwVBZ+88Mrzbuvn9olPsfv43mbiWaFY+nRcz/TGGku0/lc2FepdMbImdMY1JrQ+zbw==",
       "dev": true
     },
     "abbrev": {
@@ -237,7 +237,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -449,7 +449,7 @@
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -464,7 +464,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -648,31 +648,54 @@
       }
     },
     "electron": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.8.8.tgz",
-      "integrity": "sha512-1f9zJehcTTGjrkb06o6ds+gsRq6SYhZJyxOk6zIWjRH8hVy03y/RzUDELzNas71f5vcvXmfGVvyjeEsadDI8tg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-3.0.4.tgz",
+      "integrity": "sha512-GuZ4xCmV8wNNfkUAOdmOmgkYYaTQj5LATzc2i/b3MGhoXghnjECCgxo5yW+G2BeKM+R30cg69KA03tRzmIFxxQ==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",
-        "electron-download": "^3.0.1",
+        "electron-download": "^4.1.0",
         "extract-zip": "^1.0.3"
       }
     },
     "electron-download": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
-      "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-4.1.1.tgz",
+      "integrity": "sha512-FjEWG9Jb/ppK/2zToP+U5dds114fM1ZOJqMAR4aXXL5CvyPE9fiqBK/9YcwC9poIFQTEJk/EM/zyRwziziRZrg==",
       "dev": true,
       "requires": {
-        "debug": "^2.2.0",
-        "fs-extra": "^0.30.0",
-        "home-path": "^1.0.1",
+        "debug": "^3.0.0",
+        "env-paths": "^1.0.0",
+        "fs-extra": "^4.0.1",
         "minimist": "^1.2.0",
-        "nugget": "^2.0.0",
-        "path-exists": "^2.1.0",
-        "rc": "^1.1.2",
-        "semver": "^5.3.0",
-        "sumchecker": "^1.2.0"
+        "nugget": "^2.0.1",
+        "path-exists": "^3.0.0",
+        "rc": "^1.2.1",
+        "semver": "^5.4.1",
+        "sumchecker": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
       }
     },
     "electron-osx-sign": {
@@ -839,12 +862,6 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
-      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1365,16 +1382,25 @@
       }
     },
     "fs-extra": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
       }
     },
     "fs.realpath": {
@@ -1600,12 +1626,6 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
-    "home-path": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.6.tgz",
-      "integrity": "sha512-wo+yjrdAtoXt43Vy92a+0IPCYViiyLAHyp0QVS4xL/tfvVz5sXIW1ubLZk3nhVkD92fQpUMKX+fzMjr5F489vw==",
-      "dev": true
-    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -1718,7 +1738,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
@@ -2071,7 +2091,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -2178,7 +2198,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -2428,7 +2448,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
     "progress": {
@@ -2622,7 +2642,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "^7.0.5"
@@ -2657,7 +2677,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "safer-buffer": {
@@ -2731,7 +2751,7 @@
     "spdx-correct": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-      "integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -2741,13 +2761,13 @@
     "spdx-exceptions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha1-LHrmEFbHFKW5ubKyr30xHvXHj+k=",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -2840,13 +2860,12 @@
       "dev": true
     },
     "sumchecker": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
-      "integrity": "sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
+      "integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
       "dev": true,
       "requires": {
-        "debug": "^2.2.0",
-        "es6-promise": "^4.0.5"
+        "debug": "^2.2.0"
       }
     },
     "supports-color": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -19,7 +19,7 @@
     "push": "git pull ; npm run build ; npm run push_theme ; npm run push_osx ; npm run push_linux ; npm run push_win ; npm run clean ; npm run push_status"
   },
   "devDependencies": {
-    "electron": "^1.8.8",
+    "electron": "^3.0.4",
     "electron-packager": "^12.1.1",
     "eslint": "^5.6.1",
     "eslint-config-standard": "^12.0.0",

--- a/desktop/sources/left.js
+++ b/desktop/sources/left.js
@@ -59,6 +59,9 @@ function Left () {
       if (!this.reader.active) { this.stats.on_scroll() }
     })
 
+    // Trigger update when selection changes
+    this.textarea_el.addEventListener('select', (e) => { this.update() })
+
     this.textarea_el.addEventListener('input', () => {
       this.project.page().commit()
     })

--- a/desktop/sources/left.js
+++ b/desktop/sources/left.js
@@ -60,7 +60,9 @@ function Left () {
     })
 
     // Trigger update when selection changes
-    this.textarea_el.addEventListener('select', (e) => { this.update() })
+    this.textarea_el.addEventListener('select', (e) => {
+      if (!this.reader.active) { this.update() }
+    })
 
     this.textarea_el.addEventListener('input', () => {
       this.project.page().commit()

--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -22,27 +22,12 @@ body navi li i { padding-right:15px; }
 body navi > ul {  }
 body navi > ul li.marker { display: none }
 body navi > ul.active li.marker { display: block }
-body stats { display: block;border-bottom: 0px;margin-top: 30px;position: fixed;bottom:0px;left: 25vw;line-height: 40px;width:calc(75vw - 40px);height:40px;overflow: auto;-webkit-user-select: none;-webkit-app-region: drag; transition: left 200ms; }
-body stats b { }
-body stats i { text-decoration: underline; }
-body stats .right { float:right; }
-
-body stats ul {
-  height: 100%;
-  display: inline;
-  overflow: scroll;
-}
-
-body stats li {
-  display: inline;
-  margin-right: 20px;
-}
-
-body stats li.active {
-  text-decoration: underline;
-  font-weight: bold;
-}
-
+body stats { display: block; border-bottom: 0; margin-top: 30px; position: fixed; bottom: 0; left: 25vw; line-height: 40px; width: calc(75vw - 40px); height: 40px; overflow: auto; -webkit-user-select: none; -webkit-app-region: drag; transition: left 200ms; }
+body stats i {text-decoration: underline; }
+body stats .right { float: right; }
+body stats ul { height: 100%; display: inline; overflow: scroll; white-space: nowrap; }
+body stats li { display: inline; margin-right: 20px; }
+body stats li.active { text-decoration: underline; font-weight: bold; }
 
 body textarea { font-family: var(--font-family); padding: 90px 15px 0; height: calc(100vh - 130px); display: block; width: 50vw; position: fixed; left: 25vw; font-size: var(--font-size); line-height: var(--line-height); resize: none; background: transparent; overflow: auto; max-width: 90%; transition: left 200ms; margin-left:-15px; }
 body div { left: 25vw; max-width:600px; width:50vw; line-height: var(--line-height); font-family: var(--font-family); font-size: var(--font-size); white-space: pre-wrap; word-wrap:break-word; }

--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -22,10 +22,28 @@ body navi li i { padding-right:15px; }
 body navi > ul {  }
 body navi > ul li.marker { display: none }
 body navi > ul.active li.marker { display: block }
-body stats { display: block;border-bottom: 0px;margin-top: 30px;position: fixed;bottom:0px;left: 25vw;line-height: 40px;width:calc(75vw - 40px);height:40px;overflow: hidden;-webkit-user-select: none;-webkit-app-region: drag; transition: left 200ms; }
+body stats { display: block;border-bottom: 0px;margin-top: 30px;position: fixed;bottom:0px;left: 25vw;line-height: 40px;width:calc(75vw - 40px);height:40px;overflow: auto;-webkit-user-select: none;-webkit-app-region: drag; transition: left 200ms; }
 body stats b { }
 body stats i { text-decoration: underline; }
 body stats .right { float:right; }
+
+body stats ul {
+  height: 100%;
+  display: inline;
+  overflow: scroll;
+}
+
+body stats li {
+  display: inline;
+  margin-right: 20px;
+}
+
+body stats li.active {
+  text-decoration: underline;
+  font-weight: bold;
+}
+
+
 body textarea { font-family: var(--font-family); padding: 90px 15px 0; height: calc(100vh - 130px); display: block; width: 50vw; position: fixed; left: 25vw; font-size: var(--font-size); line-height: var(--line-height); resize: none; background: transparent; overflow: auto; max-width: 90%; transition: left 200ms; margin-left:-15px; }
 body div { left: 25vw; max-width:600px; width:50vw; line-height: var(--line-height); font-family: var(--font-family); font-size: var(--font-size); white-space: pre-wrap; word-wrap:break-word; }
 body drag { display: block;width: 100vw;height: 40px;position: fixed;top: 0px;-webkit-user-select: none;-webkit-app-region: drag; background-color: transparent !important;}

--- a/desktop/sources/scripts/events.js
+++ b/desktop/sources/scripts/events.js
@@ -7,7 +7,6 @@ document.onkeydown = function keyDown (e) {
   if (e.keyCode === 9) {
     if (e.shiftKey) {
       left.stats.nextSynonym()
-      // left.select_synonym()
     } else {
       left.select_autocomplete()
     }
@@ -46,7 +45,6 @@ document.onkeydown = function keyDown (e) {
 
 document.onkeyup = (e) => {
   if (e.keyCode === 16) { // Shift
-    // left.selection.index = 0
     left.stats.applySynonym()
     left.update()
     return

--- a/desktop/sources/scripts/events.js
+++ b/desktop/sources/scripts/events.js
@@ -6,7 +6,8 @@ document.onkeydown = function keyDown (e) {
   // Faster than Electron
   if (e.keyCode === 9) {
     if (e.shiftKey) {
-      left.select_synonym()
+      left.stats.nextSynonym()
+      // left.select_synonym()
     } else {
       left.select_autocomplete()
     }
@@ -45,7 +46,8 @@ document.onkeydown = function keyDown (e) {
 
 document.onkeyup = (e) => {
   if (e.keyCode === 16) { // Shift
-    left.selection.index = 0
+    // left.selection.index = 0
+    left.stats.applySynonym()
     left.update()
     return
   }

--- a/desktop/sources/scripts/events.js
+++ b/desktop/sources/scripts/events.js
@@ -54,17 +54,6 @@ document.onkeyup = (e) => {
   }
 }
 
-// Selection Change
-let lastSelection = null
-
-window.addEventListener('mousemove', function (e) {
-  if (lastSelection && lastSelection.start === left.textarea_el.selectionStart && lastSelection.end === left.textarea_el.selectionEnd) {
-    return
-  }
-  left.update()
-  lastSelection = { start: left.textarea_el.selectionStart, end: left.textarea_el.selectionEnd }
-})
-
 window.addEventListener('dragover', function (e) {
   e.stopPropagation()
   e.preventDefault()

--- a/desktop/sources/scripts/reader.js
+++ b/desktop/sources/scripts/reader.js
@@ -56,6 +56,8 @@ function Reader () {
   }
 
   this.stop = function () {
+    if (!this.active) { return }
+
     left.controller.set('default')
     this.segment = { from: 0, to: 0, text: '', words: [] }
     this.queue = []

--- a/desktop/sources/scripts/stats.js
+++ b/desktop/sources/scripts/stats.js
@@ -56,7 +56,7 @@ function Stats () {
     previousWord.classList.remove('active')
     currentWord.classList.add('active')
 
-    if (currentWord.offsetLeft > (window.innerWidth * 0.75 - 40) / 2) {
+    if (currentWord.offsetLeft > this.el.offsetWidth / 2) {
       this.el.scrollLeft += (20 + currentWord.offsetWidth)
     } else {
       this.el.scrollLeft = 0

--- a/desktop/sources/scripts/stats.js
+++ b/desktop/sources/scripts/stats.js
@@ -91,16 +91,6 @@ function Stats () {
     this.list = ul
 
     return ul
-
-    // // Populate the stats
-    // let underlinedSyn = left.synonyms[left.selection.index]
-    // let html = `<b>${left.selection.word}</b> <i>${underlinedSyn}</i> `
-    //
-    // for (let i = left.selection.index + 1; i < left.synonyms.length; i += 1) {
-    //   html += `${left.synonyms[i]} `
-    // }
-    //
-    // return html
   }
 
   this._suggestion = function () {

--- a/desktop/sources/scripts/stats.js
+++ b/desktop/sources/scripts/stats.js
@@ -56,26 +56,19 @@ function Stats () {
     previousWord.classList.remove('active')
     currentWord.classList.add('active')
 
-    if (currentWord.offsetLeft > this.el.offsetWidth / 2) {
-      this.el.scrollLeft += (20 + currentWord.offsetWidth)
-    } else {
-      this.el.scrollLeft = 0
-    }
-
-    console.log(`Next synonym: ${left.synonyms[left.selection.index]}`)
+    currentWord.scrollIntoView({
+      behavior: 'smooth'
+    })
   }
 
   this.applySynonym = function () {
     if (!this.isSynonymsActive) { return }
-
-    console.log(`Apply the synonym: ${left.synonyms[left.selection.index % left.synonyms.length]}`)
 
     // Replace the current word with the selected synonym
     left.replace_active_word_with(left.synonyms[left.selection.index % left.synonyms.length])
   }
 
   this._synonyms = function () {
-    console.warn('Populate the synonyms.')
     left.selection.index = 0
 
     const ul = document.createElement('ul')
@@ -87,7 +80,9 @@ function Stats () {
     })
 
     ul.children[0].classList.add('active')
-    this.el.scrollLeft = 0
+    ul.children[0].scrollIntoView({
+      behavior: 'smooth'
+    })
     this.list = ul
 
     return ul


### PR DESCRIPTION
This pull request fixes issue #91.

- Replaces a `mousemove` event listener with `select` that triggers updates less often
- Synonym logic improved slightly, multiple `left.update()` calls avoided
- Synonyms are shown as a list in the stats, cycling through synonyms will scroll the appropriate one into view and highlight it
- Releasing the <kbd>Shift</kbd> key while the desired synonym is active will replace the current word
- <kbd>Cmd+Z</kbd> will now return to the original word as only one replacement is made
- Upgrades to Electron 3.0.0!