### PR TITLE
Update guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Guide
 
-View the [guide](https://100r.co/blog.html#left)
+View the [guide](https://100r.co/pages/left.html)
 
 ## Install
 


### PR DESCRIPTION
Old link just redirected to the homepage of 100r. Now this will link directly to the Left page.