### PR TITLE
Remove app.inspect call when app is ready

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -23,7 +23,6 @@ app.on('ready', () => {
   })
 
   app.win.loadURL(`file://${__dirname}/sources/index.html`)
-  app.inspect()
 
   app.win.on('closed', () => {
     win = null


### PR DESCRIPTION
Otherwise DevTools opens up on every app launch.