### PR TITLE
Always show the current minute with two digits

### DIFF
--- a/desktop/sources/scripts/stats.js
+++ b/desktop/sources/scripts/stats.js
@@ -32,7 +32,7 @@ function Stats () {
   this._default = function () {
     let stats = this.parse(left.selected())
     let date = new Date()
-    return `${stats.l}L ${stats.w}W ${stats.v}V ${stats.c}C ${stats.p}% <span class='right'>${date.getHours()}:${date.getMinutes()}</span>`
+    return `${stats.l}L ${stats.w}W ${stats.v}V ${stats.c}C ${stats.p}% <span class='right'>${date.getHours()}:${('0' + date.getMinutes()).slice(-2)}</span>`
   }
 
   this.incrementSynonym = function () {


### PR DESCRIPTION
This patch ensures that the current time is always displayed with two digits for the minute, so that for example at 9:05 AM the time is shown as "9:05" instead of as "9:5".