### PR TITLE
Use the correct app path on dialogs

### DIFF
--- a/desktop/sources/scripts/project.js
+++ b/desktop/sources/scripts/project.js
@@ -141,7 +141,7 @@ function Project () {
         buttons: ['Yes', 'No'],
         title: 'Confirm',
         message: 'Are you sure you want to discard changes?',
-        icon: `${app.path()}/icon.png`
+        icon: `${app.getAppPath()}/icon.png`
       })
       if (response !== 0) {
         return
@@ -166,7 +166,7 @@ function Project () {
       buttons: ['Yes', 'No'],
       title: 'Confirm',
       message: 'Are you sure you want to discard changes?',
-      icon: `${app.path()}/icon.png`
+      icon: `${app.getAppPath()}/icon.png`
     })
     if (response === 0) { // Runs the following if 'Yes' is clicked
       left.reload(true)
@@ -194,7 +194,7 @@ function Project () {
       buttons: ['Yes', 'No'],
       title: 'Confirm',
       message: 'Unsaved data will be lost. Are you sure you want to quit?',
-      icon: `${app.path()}/icon.png`
+      icon: `${app.getAppPath()}/icon.png`
     })
     if (response === 0) {
       app.exit()


### PR DESCRIPTION
Hey 👋 

The `app.path()` was throwing this error when I tried to `cmd + q` an unsaved file: 

![image](https://user-images.githubusercontent.com/3016692/60888351-f7226d00-a22c-11e9-818f-234c6adf35ec.png)

This PR aims to fix it.
