### PR TITLE
Added way for windows users to disable the frame with a shortcut arg 

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -16,7 +16,7 @@ app.on('ready', () => {
     backgroundColor: '#000',
     icon: path.join(__dirname, { darwin: 'icon.icns', linux: 'icon.png', win32: 'icon.ico' }[process.platform] || 'icon.ico'),
     resizable: true,
-    frame: process.platform !== 'darwin',
+    frame: (process.argv.indexOf('frameless') == -1) && (process.platform !== 'darwin'),
     skipTaskbar: process.platform === 'darwin',
     autoHideMenuBar: process.platform === 'darwin',
     webPreferences: { zoomFactor: 1.0, nodeIntegration: true, backgroundThrottling: false }


### PR DESCRIPTION
If a windows user creates a shortcut, and adds "frameless" to the target field, the frame will be disabled. 
![image](https://user-images.githubusercontent.com/35883424/63647454-d929b100-c775-11e9-9e54-16dbb0dfbc6c.png)
