### PR TITLE
Small change on textarea width and reload of modified file

### DIFF
--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -34,8 +34,8 @@ body stats ul { height: 100%; display: inline; overflow: scroll; white-space: no
 body stats li { display: inline; margin-right: 10px; }
 body stats li.active { text-decoration: underline; font-weight: bold; }
 
-body textarea { font-family: var(--font-family); padding: 30px 15px 0; height: calc(100vh - 90px); display: block; width: 50vw; position: fixed; left: 25vw; font-size: var(--font-size); line-height: var(--line-height); resize: none; background: transparent; overflow: auto; max-width: 90%; transition: left 200ms; margin-left:-15px; }
-body div { left: 25vw; max-width:600px; width:50vw; line-height: var(--line-height); font-family: var(--font-family); font-size: var(--font-size); white-space: pre-wrap; word-wrap:break-word; }
+body textarea { font-family: var(--font-family); padding: 30px 15px 0; height: calc(100vh - 90px); display: block; width: 80ch; position: fixed; left: 25vw; font-size: var(--font-size); line-height: var(--line-height); resize: none; background: transparent; overflow: auto; max-width: 90%; transition: left 200ms; margin-left:-15px; }
+body div { left: 25vw; max-width:600px; width:80ch; line-height: var(--line-height); font-family: var(--font-family); font-size: var(--font-size); white-space: pre-wrap; word-wrap:break-word; }
 body drag { display: block;width: 100vw;height: 30px;position: fixed;top: 0px;-webkit-user-select: none;-webkit-app-region: drag; background-color: transparent !important;}
 
 body #operator { display: block;border-bottom: 0px;margin-top: 30px;position: fixed;bottom: 0px;left: 25vw;;line-height: 40px;width:calc(75vw - 40px);height: 40px;overflow: hidden;-webkit-user-select: none;-webkit-app-region: no-drag; bottom:-40px; transition: bottom 150ms }

--- a/desktop/sources/scripts/page.js
+++ b/desktop/sources/scripts/page.js
@@ -32,7 +32,7 @@ function Page (text = '', path = null) {
         type: "question",
         title: "Confirm",
         message: "File was modified outside Left. Do you want to reload it?",
-        buttons: ['Yes', 'No', 'Ignore future ocurrencies'],
+        buttons: ['Yes', 'No', 'Ignore future occurrencies'],
         detail: `New size of file is: ${this.size} bytes.`,
         icon: `${app.getAppPath()}/icon.png`
       })


### PR DESCRIPTION
Commit ddf2310: Expands the textarea to exactly 80 chars as is a commonly used standard for line width (and helps keeping everything tidy).

Commit 4aa7926: Introduces an idea taken mainly from Atom to be able to reload a file that was modified externally by another application. It also includes an "Ignore all" button if it gets too annoying.