### PR TITLE
Added a Linux installation script & desktop file.

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,11 +10,11 @@
     "fix": "standard --fix",
     "clean": "rm -r ~/Documents/Left-darwin-x64/ ; rm -r ~/Documents/Left-linux-x64/ ; rm -r ~/Documents/Left-win32-x64/ ; echo 'cleaned build location'",
     "build_osx": "electron-packager . Left --platform=darwin --arch=x64 --out ~/Documents/ --overwrite --icon=icon.icns ; echo 'Built for OSX'",
-    "build_linux": "electron-packager . Left --platform=linux  --arch=x64 --out ~/Documents/ --overwrite --icon=icon.ico ; echo 'Built for LINUX'",
+    "build_linux": "electron-packager . left --platform=linux  --arch=x64 --out ~/Documents/ --overwrite --icon=icon.ico ; cp ../post_install/* ~/Documents/left-linux-x64/ ; echo 'Built for LINUX'",
     "build_win": "electron-packager . Left --platform=win32  --arch=x64 --out ~/Documents/ --overwrite --icon=icon.ico ; echo 'Built for WIN'",
     "build": "npm run clean ; npm run build_osx ; npm run build_linux ; npm run build_win",
     "push_osx": "~/Applications/butler push ~/Documents/Left-darwin-x64/ hundredrabbits/left:osx-64",
-    "push_linux": "~/Applications/butler push ~/Documents/Left-linux-x64/ hundredrabbits/left:linux-64",
+    "push_linux": "~/Applications/butler push ~/Documents/left-linux-x64/ hundredrabbits/left:linux-64",
     "push_win": "~/Applications/butler push ~/Documents/Left-win32-x64/ hundredrabbits/left:windows-64",
     "status": "~/Applications/butler status hundredrabbits/left",
     "push": "npm run build ; npm run push_osx ; npm run push_linux ; npm run push_win ; npm run clean ; npm run status"

--- a/post_install/install.sh
+++ b/post_install/install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Copy the application to the user's /opt folder.
+sudo cp -r ../* /opt/
+
+# Copy the left.desktop file to the user's local applications folder.
+sudo cp left.desktop ~/.local/share/applications/
+
+# Installation complete.
+echo "Left has been installed. Enjoy!"

--- a/post_install/left.desktop
+++ b/post_install/left.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=Left
+GenericName=Text Editor
+Comment=Edit text files
+Exec=/opt/left-linux-x64/left
+Terminal=false
+Type=Application
+Keywords=Text;Editor;
+Icon=/opt/left-linux-x64/resources/app/icon.png
+Categories=Utility;TextEditor;
+StartupNotify=false
+MimeType=text/plain;


### PR DESCRIPTION
I added a simple Linux installation script with a prebuilt desktop file. I changed the "build_linux" script to adapt to the post-build and downloaded source structure. A Linux user can now install Left globally with ease.