### PR TITLE
update tabulation

### DIFF
--- a/desktop/sources/left.js
+++ b/desktop/sources/left.js
@@ -107,7 +107,7 @@ function Left () {
     if (this.selection.word.trim() !== '' && this.suggestion && this.suggestion.toLowerCase() !== this.active_word().toLowerCase()) {
       this.autocomplete()
     } else {
-      this.inject('\u00a0\u00a0')
+      this.inject('\t')
     }
   }
 

--- a/desktop/sources/links/main.css
+++ b/desktop/sources/links/main.css
@@ -4,7 +4,7 @@
 
 ::-webkit-scrollbar { display: none; margin: 0; padding: 0; }
 
-body { height: 100vh; font-family: var(--font-family); font-size: 12px; overflow: auto; transition: background-color 500ms,filter 150ms; overflow: hidden;}
+body { tab-size: 2; height: 100vh; font-family: var(--font-family); font-size: 12px; overflow: auto; transition: background-color 500ms,filter 150ms; overflow: hidden;}
 body navi { display: block;width: calc((100vw / 4) - 40px);left: 0px;position: absolute;padding: 30px 0px 0px 30px; -webkit-user-select: none;-webkit-app-region: drag;overflow: auto;padding-top:30px;transition: opacity 200ms 200ms, translateY 150ms, width 200ms; opacity:1; height: calc(100vh - 120px); padding-bottom: 40px;}
 body navi li { display: flex; flex-direction: row; justify-content: space-between; align-items: center; line-height: 20px; cursor: pointer; position: relative; -webkit-app-region: no-drag; height:20px;}
 body navi li span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }


### PR DESCRIPTION
Summary of changes: update tabulation from `\u00a0\u00a0` to `\t` (hard tab), and update `tab-size` in the CSS to be consistent.

Reasoning: Most programs don't seem to recognize `\u00a0\u00a0` as a tab or even as whitespace. While this is probably fine when all you're doing is (for example) writing notes for personal use, it doesn't seem very helpful when you want to use the file in a different program.

Notes: Looking at the code, it appears soft tabs are the preferred style. If necessary, I might be able to implement an option to switch between hard tabs (as it is now) and soft tabs.