### PR TITLE
Use paths.filePaths and handle promise in showOpenDialog

### DIFF
--- a/desktop/sources/scripts/lib/theme.js
+++ b/desktop/sources/scripts/lib/theme.js
@@ -76,11 +76,13 @@ function Theme (_default) {
   this.open = function () {
     const fs = require('fs')
     const { dialog, app } = require('electron').remote
-    const paths = dialog.showOpenDialog(app.win, { properties: ['openFile'], filters: [{ name: 'Themes', extensions: ['svg'] }] })
-    if (!paths) { console.log('Nothing to load'); return }
-    fs.readFile(paths[0], 'utf8', function (err, data) {
-      if (err) throw err
-      themer.load(data)
+    dialog.showOpenDialog(app.win, { properties: ['openFile'], filters: [{ name: 'Themes', extensions: ['svg'] }] })
+    .then(function (paths) {
+      if (paths.filePaths.length < 1) { console.log('Nothing to load'); return }
+      fs.readFile(paths.filePaths[0], 'utf8', function (err, data) {
+        if (err) throw err
+        themer.load(data)
+      })
     })
   }
 


### PR DESCRIPTION
[.showOpenDialog()](https://www.electronjs.org/docs/api/dialog#dialogshowopendialogbrowserwindow-options) returns a promise, which resolves with an object instead of an array. Also fixes #144.