### PR TITLE
Added missing shortcut for menu bar toggling

### DIFF
--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -74,6 +74,7 @@
       left.controller.add('default', 'Navigation', 'Prev Marker', () => { left.navi.prev_marker() }, 'CmdOrCtrl+[')
 
       left.controller.add('default', 'View', 'Toggle Navigation', () => { left.navi.toggle() }, 'CmdOrCtrl+\\')
+      left.controller.add('default', 'View', 'Toggle Menubar', () => { app.toggleMenubar() }, 'F11')
       left.controller.add('default', 'View', 'Previous Font', () => { left.font.previousFont() }, 'CmdOrCtrl+Shift+,')
       left.controller.add('default', 'View', 'Next Font', () => { left.font.nextFont() }, 'CmdOrCtrl+Shift+.')
       left.controller.add('default', 'View', 'Decrease Font Size', () => { left.font.decreaseFontSize() }, 'CmdOrCtrl+-')


### PR DESCRIPTION
I have added a shortcut and menu entry which allows to toggle the menu bar by pressing `F11`. It calls the already existing function in `dekstop/main.js` (line 63):

```js
app.toggleMenubar = function () {
  app.win.setMenuBarVisibility(!app.win.isMenuBarVisible())
}
```

Menu entry:

![image](https://user-images.githubusercontent.com/34947398/125514917-43d4308b-4083-456c-b074-e3f188b31cdb.png)

Toggle by mouse-tap and pressing `F11`:

![toggle-menu-test](https://user-images.githubusercontent.com/34947398/125514798-be470905-63f6-4cb6-a4f3-682a4e90dd39.gif)
