### PR TITLE
Adding Options tab bar and remembering window size

### DIFF
--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -88,6 +88,9 @@
       left.controller.addSpacer('default', 'Theme', 'Download')
       left.controller.add("default","Theme","Download Themes..",() => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Themes') })
 
+      left.controller.add("default","Options","Set Text Area Width",() => { left.operator.start('setTextAreaColumns: ')})
+      left.controller.add("default","Options","Save Window Size",() => { left.options.setDimensions()})
+
       left.controller.add('reader', '*', 'About', () => { require('electron').shell.openExternal('https://github.com/hundredrabbits/Left') }, 'CmdOrCtrl+,')
       left.controller.add('reader', '*', 'Fullscreen', () => { app.toggleFullscreen() }, 'CmdOrCtrl+Enter')
       left.controller.add('reader', '*', 'Hide', () => { app.toggleVisible() }, 'CmdOrCtrl+H')
@@ -128,6 +131,8 @@
       left.controller.add('operator', 'Find', 'Find', () => { left.operator.start('find: ') }, 'CmdOrCtrl+F')
       left.controller.add('operator', 'Find', 'Find Next', () => { left.operator.find_next() }, 'CmdOrCtrl+N')
       left.controller.add('operator', 'Operator', 'Stop', () => { left.operator.stop() }, 'Esc')
+
+      left.controller.add('operator', 'Options', 'setTextAreaColumns', () => { left.operator.start('setTextAreaColumns: ') })
 
       left.controller.commit()
     </script>

--- a/desktop/sources/left.js
+++ b/desktop/sources/left.js
@@ -11,6 +11,7 @@ const Project = require('./scripts/project')
 const Reader = require('./scripts/reader')
 const Insert = require('./scripts/insert')
 const Font = require('./scripts/font')
+const Options = require('./scripts/options')
 
 const EOL = '\n'
 
@@ -18,7 +19,8 @@ function Left () {
   this.theme = new Theme({ background: '#222', f_high: '#eee', f_med: '#888', f_low: '#666', f_inv: '#00f', b_high: '#f9a', b_med: '#a9f', b_low: '#000', b_inv: '#af9' })
   this.controller = new Controller()
   this.dictionary = new Dictionary()
-  this.operator = new Operator()
+  this.options = new Options()
+  this.operator = new Operator(this.options)
   this.navi = new Navi()
   this.stats = new Stats()
   this.go = new Go()
@@ -78,6 +80,7 @@ function Left () {
     this.font.start()
     this.dictionary.start()
     this.project.start()
+    this.options.start()
 
     this.go.to_page()
 
@@ -328,6 +331,7 @@ function Left () {
   this.reset = () => {
     this.theme.reset()
     this.font.reset()
+    //this.options.reset()
     this.update()
   }
 

--- a/desktop/sources/scripts/operator.js
+++ b/desktop/sources/scripts/operator.js
@@ -1,11 +1,14 @@
 'use strict'
 
+const Options = require("./options");
+
 const EOL = '\n'
 
-function Operator () {
+function Operator (options) {
   this.el = document.createElement('input'); this.el.id = 'operator'
   this.is_active = false
   this.index = 0
+  this.Options = options
 
   this.el.addEventListener('keyup', (e) => { left.operator.on_change(e, false) })
   this.el.addEventListener('keydown', (e) => { left.operator.on_change(e, true) })
@@ -166,6 +169,14 @@ function Operator () {
       this.stop()
       left.go.to_line(target)
     }
+  }
+
+  this.setTextAreaColumns = function (size) {
+    if (size.length < 2) { return }
+    console.log("setTextAreaColumns operator: " + size)
+    this.Options.setTAWidth(size)
+
+    return
   }
 }
 

--- a/desktop/sources/scripts/operator.js
+++ b/desktop/sources/scripts/operator.js
@@ -171,12 +171,13 @@ function Operator (options) {
     }
   }
 
-  this.setTextAreaColumns = function (size) {
+  this.setTextAreaColumns = function (size, bang = false) {
     if (size.length < 2) { return }
-    console.log("setTextAreaColumns operator: " + size)
-    this.Options.setTAWidth(size)
+    this.Options.setTextAreaColumns(size)
 
-    return
+    if (bang) {
+      setTimeout(() => { left.operator.stop() }, 250)
+    }
   }
 }
 

--- a/desktop/sources/scripts/options.js
+++ b/desktop/sources/scripts/options.js
@@ -1,39 +1,25 @@
 'use strict'
 
 function Options () {
+  this.electron = require('electron');
   const root = document.documentElement
-  //this.element = null
   this.colWidth = 80
   this.w = 500
   this.h = 500
 
-  this.electron = require('electron');
-    
-  //this.c = document.querySelector("#calls")
-  //this.timeout = false // holder for timeout id
-  //this.delay = 250 // delay after event is "complete" to run callback
-  //this.calls = 0
 
   this.setDimensions = function () {
     var window = this.electron.remote.getCurrentWindow();
     const { w, h } = window.getSize()
-    console.log(window.getSize())
     this.w = window.getSize()[0]
     this.h = window.getSize()[1]
-    // this.calls += 1;
-    // this.c = calls;
-
-    console.log("setDimensions: " + this.w +  " x " +  this.h )//+ ",,, " + this.calls)
-
     this.updateVariables()
   }
 
   this.start = function () {
-    
     this.element = document.querySelector('textarea')
-    console.log(this.element)
-    console.log(root)
-    // If localStorage has information about the font,
+
+    // If localStorage has information about the options,
     // load the saved values and apply them
     if (localStorage.getItem('options')) {
       console.log(JSON.parse(localStorage.getItem('options')))
@@ -41,44 +27,22 @@ function Options () {
       this.colWidth = colWidth
       this.w = w
       this.h = h
-
       this.updateVariables()
     }
-
-    // window.addEventListener('resize', function() {
-    //     clearTimeout(this.timeout);
-    //     this.timeout = setTimeout(getDimensions, 250);
-    //   });
-
   }
 
-  this.setTAWidth = function (size) {
-    console.log("setTAWidth: size")
+  this.setTextAreaColumns = function (size) {
     this.colWidth = size
     this.updateVariables()
   }
 
-  // window.resize callback function
-
-
   // Update the CSS variables, save the values to localStorage
   this.updateVariables = function () {
-    console.log("updating options ... ")
     this.element.style.setProperty('width', `${this.colWidth}ch`)
-    // root.style.setProperty('width', `${this.w}px`)
-    // root.style.setProperty('max-width', `${this.h}px`)
-
-    // root.style.width = `${this.w}px`;
-
-
-    // console.log(window)
     var window = this.electron.remote.getCurrentWindow();
-    console.log("setting window: " + this.w +  " x " +  this.h)
     window.setSize(this.w, this.h)
-
+    window.center()
     this.save()
-
-    console.log("geting window: " + window.getSize())
   }
 
   // Save the font-related values to localStorage

--- a/desktop/sources/scripts/options.js
+++ b/desktop/sources/scripts/options.js
@@ -1,0 +1,94 @@
+'use strict'
+
+function Options () {
+  const root = document.documentElement
+  //this.element = null
+  this.colWidth = 80
+  this.w = 500
+  this.h = 500
+
+  this.electron = require('electron');
+    
+  //this.c = document.querySelector("#calls")
+  //this.timeout = false // holder for timeout id
+  //this.delay = 250 // delay after event is "complete" to run callback
+  //this.calls = 0
+
+  this.setDimensions = function () {
+    var window = this.electron.remote.getCurrentWindow();
+    const { w, h } = window.getSize()
+    console.log(window.getSize())
+    this.w = window.getSize()[0]
+    this.h = window.getSize()[1]
+    // this.calls += 1;
+    // this.c = calls;
+
+    console.log("setDimensions: " + this.w +  " x " +  this.h )//+ ",,, " + this.calls)
+
+    this.updateVariables()
+  }
+
+  this.start = function () {
+    
+    this.element = document.querySelector('textarea')
+    console.log(this.element)
+    console.log(root)
+    // If localStorage has information about the font,
+    // load the saved values and apply them
+    if (localStorage.getItem('options')) {
+      console.log(JSON.parse(localStorage.getItem('options')))
+      const { colWidth, w, h } = JSON.parse(localStorage.getItem('options'))
+      this.colWidth = colWidth
+      this.w = w
+      this.h = h
+
+      this.updateVariables()
+    }
+
+    // window.addEventListener('resize', function() {
+    //     clearTimeout(this.timeout);
+    //     this.timeout = setTimeout(getDimensions, 250);
+    //   });
+
+  }
+
+  this.setTAWidth = function (size) {
+    console.log("setTAWidth: size")
+    this.colWidth = size
+    this.updateVariables()
+  }
+
+  // window.resize callback function
+
+
+  // Update the CSS variables, save the values to localStorage
+  this.updateVariables = function () {
+    console.log("updating options ... ")
+    this.element.style.setProperty('width', `${this.colWidth}ch`)
+    // root.style.setProperty('width', `${this.w}px`)
+    // root.style.setProperty('max-width', `${this.h}px`)
+
+    // root.style.width = `${this.w}px`;
+
+
+    // console.log(window)
+    var window = this.electron.remote.getCurrentWindow();
+    console.log("setting window: " + this.w +  " x " +  this.h)
+    window.setSize(this.w, this.h)
+
+    this.save()
+
+    console.log("geting window: " + window.getSize())
+  }
+
+  // Save the font-related values to localStorage
+  this.save = function () {
+    localStorage.setItem('options', JSON.stringify({
+      colWidth: this.colWidth, 
+      w: this.w,
+      h: this.h
+    }))
+  }
+}
+
+module.exports = Options


### PR DESCRIPTION
Created an Options tab that currently adds two features:  
Set Text Area Width - allows you to change the text area size by supplying a number and hitting enter, esc, or right clicking in the app
Save Window Size - saves current window size to local storage and resizes/centers window after app starts up. 

Will happily take comments or suggestions on what else to add! Hopefully this opens the door to have some extra customization in the editor. 