### PR TITLE
adding default txt file type to save

### DIFF
--- a/desktop/sources/scripts/project.js
+++ b/desktop/sources/scripts/project.js
@@ -117,7 +117,11 @@ function Project () {
     console.log('Save As Page')
 
     const page = this.page()
-    const path = dialog.showSaveDialogSync(app.win)
+    const path = dialog.showSaveDialogSync(app.win, {
+      filters: [
+        { name: 'Text Documents (*.txt)', extensions: ['txt'] },
+        { name: 'All Files', extensions: ['*'] }]
+      })
 
     if (!path) { console.log('Nothing to save'); return }
 


### PR DESCRIPTION
mimics notpad functionality to default to save as text file, but allow you to switch file type in popup and save as any other type of file. 