### PR TITLE
remove check for windows

### DIFF
--- a/desktop/sources/index.html
+++ b/desktop/sources/index.html
@@ -26,9 +26,9 @@
       left.install(document.body)
       left.start()
 
-      // On Windows: open the file specified in the first argument
-      // (allows Open With and file associations on Windows)
-      if (process.platform === 'win32' && remote.process.argv.length > 1) {
+      // open the file specified in the first argument
+      // (allows Open With and file associations)
+      if (remote.process.argv.length > 1) {
         left.project.add(remote.process.argv[1])
       }
 


### PR DESCRIPTION
A very very small change that enables the use of file associations for platforms other than windows.

Additionally, this change would be needed in order to resolve #138.